### PR TITLE
Fix artifacts path

### DIFF
--- a/.github/workflows/daily-alternative.yml
+++ b/.github/workflows/daily-alternative.yml
@@ -22,7 +22,7 @@ jobs:
         mkdir artifacts
         docker run --privileged -i \
             -v /proc:/proc \
-            -v /artifacts:/artifacts \
+            -v ${PWD}/artifacts:/artifacts \
             -v ${PWD}:/working_dir \
             -w /working_dir \
             debian:latest \


### PR DESCRIPTION
Made a bit of a mistake with the path here. We create an `artifacts` folder in the current directory and then try and mount `/artifacts` in the container. Make sure we prefix it with the working directory.