### PR TITLE
Also upload weeklies of distinst based .iso

### DIFF
--- a/.github/workflows/daily-distinst.yml
+++ b/.github/workflows/daily-distinst.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   schedule:
-    - cron:  '0 0 * * *'
+    - cron:  '0 0 * * 2'
 
 jobs:
   build:

--- a/.github/workflows/daily-distinst.yml
+++ b/.github/workflows/daily-distinst.yml
@@ -1,0 +1,28 @@
+name: daily-distinst
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone Debian style build scripts
+      uses: actions/checkout@v1
+      with:
+        ref: debian-live-build
+
+    - name: Build and Upload daily .iso
+      run: |
+        mkdir artifacts
+        docker run --privileged -i \
+            -v /proc:/proc \
+            -v ${PWD}/artifacts:/artifacts \
+            -v ${PWD}:/working_dir \
+            -w /working_dir \
+            debian:latest \
+            /bin/bash -s etc/terraform-juno-daily-distinst-azure.conf "${{ secrets.key }}" "${{ secrets.secret }}" "${{ secrets.endpoint }}" "${{ secrets.bucket }}" < workflows.sh

--- a/.github/workflows/daily-distinst.yml
+++ b/.github/workflows/daily-distinst.yml
@@ -1,4 +1,4 @@
-name: daily-distinst
+name: weekly-distinst
 
 on:
   push:
@@ -11,12 +11,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Clone Debian style build scripts
+    - name: Clone build scripts
       uses: actions/checkout@v1
       with:
         ref: debian-live-build
 
-    - name: Build and Upload daily .iso
+    - name: Build and Upload distinst based .iso
       run: |
         mkdir artifacts
         docker run --privileged -i \


### PR DESCRIPTION
I've created a separate config file in the `debian-live-build` branch that can build elementary Installer/distinst based .isos. This enables GitHub actions to build them weekly. They seem pretty broken at the moment, but this at least gives us a chance to start looking into stuff.