### PR TITLE
Install ubuntu-keyring in Debian host

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ echo -e "
 "
 
 apt-get update
-apt-get install -y live-build patch
+apt-get install -y live-build patch ubuntu-keyring
 
 patch -d /usr/lib/live/build/ < live-build-fix-syslinux.patch
 


### PR DESCRIPTION
The first stage of the `live-build` process is to bootstrap a very minimal Ubuntu environment to chroot into before installing packages inside there and building the image.

Once in the chroot, Ubuntu packages can be verified as the base system comes with the Ubuntu keyring. But the initial stage of building the chroot couldn't due to the Debian host. Turns out Debian have the Ubuntu keys in their repo, so that's useful and removes some warnings during the build.