### PR TITLE
Simplify distinst live package lists

### DIFF
--- a/etc/config/package-lists.distinst/desktop.list.chroot_live
+++ b/etc/config/package-lists.distinst/desktop.list.chroot_live
@@ -1,13 +1,5 @@
 casper
-cifs-utils
-discover
 distinst
-dmraid
-fwupdate-signed
+expect
 gparted
 io.elementary.installer
-mokutil
-os-prober
-reiserfsprogs
-wamerican
-xfsprogs


### PR DESCRIPTION
This results in an installable distinst .iso (which we don't currently build in CI yet) with a fully working initial setup and onboarding flow. The live session on the .iso doesn't work properly yet (with or without this PR), but this is definitely closer to the end goal than the current config.