### PR TITLE
symlink focal script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,8 @@ echo -e "
 apt-get update
 apt-get install -y live-build patch ubuntu-keyring
 
+# TODO: Remove once live-build is able to acommodate for cases where LB_INITRAMFS is not live-boot:
+# https://salsa.debian.org/live-team/live-build/merge_requests/31
 patch -d /usr/lib/live/build/ < live-build-fix-syslinux.patch
 
 # TODO: Remove this once debootstrap 1.0.117 or newer is released and available:

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,10 @@ apt-get install -y live-build patch ubuntu-keyring
 
 patch -d /usr/lib/live/build/ < live-build-fix-syslinux.patch
 
+# TODO: Remove this once debootstrap 1.0.117 or newer is released and available:
+# https://salsa.debian.org/installer-team/debootstrap/blob/master/debian/changelog
+ln -sfn /usr/share/debootstrap/scripts/gutsy /usr/share/debootstrap/scripts/focal
+
 echo -e "
 #----------------------#
 # RUN TERRAFORM SCRIPT #


### PR DESCRIPTION
__CHANGES:__

* Link the focal debootstrap script to the gutsy script until debootstrap 1.0.117 or newer is available.

Resolves https://github.com/elementary/os/issues/277