### PR TITLE
use copy with the correct paths to fix builds that include appcenter

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,10 +48,11 @@ build () {
 
   # Symlink chosen package lists to where live-build will find them
   ln -s "package-lists.$PACKAGE_LISTS_SUFFIX" "config/package-lists"
+
   # symlink appcenter archive
   if [ "$INCLUDE_APPCENTER" = "yes" ]; then
-    ln -s "appcenter/appcenter.list.binary" "archives/appcenter.list.binary"
-    ln -s "appcenter/appcenter.key.binary" "archives/appcenter.key.binary"
+    cp "config/appcenter/appcenter.list.binary" "config/archives/appcenter.list.binary"
+    cp "config/appcenter/appcenter.key.binary" "config/archives/appcenter.key.binary"
   fi
 
   echo -e "

--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ build () {
   # Symlink chosen package lists to where live-build will find them
   ln -s "package-lists.$PACKAGE_LISTS_SUFFIX" "config/package-lists"
 
-  # symlink appcenter archive
+  # copy appcenter list & key
   if [ "$INCLUDE_APPCENTER" = "yes" ]; then
     cp "config/appcenter/appcenter.list.binary" "config/archives/appcenter.list.binary"
     cp "config/appcenter/appcenter.key.binary" "config/archives/appcenter.key.binary"


### PR DESCRIPTION
__CHANGES:__

* Fix the path to the appcenter files for builds that want to include the appcenter ppa.