### PR TITLE
use ubuntu mirrors instead of archive.ubuntu.com

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -29,8 +29,8 @@ lb config noauto \
     --parent-mirror-chroot-security "http://security.ubuntu.com/ubuntu/" \
     --mirror-binary-security "http://security.ubuntu.com/ubuntu/" \
     --parent-mirror-binary-security "http://security.ubuntu.com/ubuntu/" \
-    --mirror-binary "http://archive.ubuntu.com/ubuntu/" \
-    --parent-mirror-binary "http://archive.ubuntu.com/ubuntu/" \
+    --mirror-binary "mirror://mirrors.ubuntu.com/mirrors.txt" \
+    --parent-mirror-binary "mirror://mirrors.ubuntu.com/mirrors.txt" \
     --keyring-packages ubuntu-keyring \
     --apt-options "--yes --option Acquire::Retries=5 --option Acquire::http::Timeout=100" \
     --uefi-secure-boot enable \

--- a/etc/terraform.conf
+++ b/etc/terraform.conf
@@ -20,7 +20,7 @@ CHANNEL="stable"
 NAME="elementary OS"
 
 # mirror to fetch packages from
-MIRROR_URL="http://archive.ubuntu.com/ubuntu/"
+MIRROR_URL="http://azure.archive.ubuntu.com/ubuntu/"
 
 # use HWE kernel and packages?
 HWE="yes"


### PR DESCRIPTION
This should select better sources when setting up /etc/apt/sources.list