### PR TITLE
Disable caching

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -33,6 +33,8 @@ lb config noauto \
     --parent-mirror-binary "mirror://mirrors.ubuntu.com/mirrors.txt" \
     --keyring-packages ubuntu-keyring \
     --apt-options "--yes --option Acquire::Retries=5 --option Acquire::http::Timeout=100" \
+    --cache-packages false \
+    --cache-stages false \
     --uefi-secure-boot enable \
     --binary-images iso-hybrid \
     --iso-application "$NAME" \


### PR DESCRIPTION
Looks like the GitHub actions CI environment has been running out of space during the build recently and failing the job as a result. These are some options to not save downloaded packages and build stages to the disk in the hope it leaves us with more free space.

These options are useless in single use CI environments anyway as the cache is gone on the next build.