### PR TITLE
update website after new isos pushed

### DIFF
--- a/.github/workflows/daily-5.1.yml
+++ b/.github/workflows/daily-5.1.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           token: ${{ secrets.GIT_USER_TOKEN }}
           repository: elementary/builds
-          event-type: update
+          event-type: Update

--- a/.github/workflows/daily-5.1.yml
+++ b/.github/workflows/daily-5.1.yml
@@ -23,3 +23,10 @@ jobs:
     - name: Build and upload daily .iso
       run: |
         ./workflows.sh etc/terraform-daily-5.1-azure.conf "${{ secrets.key }}" "${{ secrets.secret }}" "${{ secrets.endpoint }}" "${{ secrets.bucket }}"
+    
+    - name: Update Website
+      uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GIT_USER_TOKEN }}
+          repository: elementary/builds
+          event-type: update

--- a/.github/workflows/daily-6.0.yml
+++ b/.github/workflows/daily-6.0.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           token: ${{ secrets.GIT_USER_TOKEN }}
           repository: elementary/builds
-          event-type: update
+          event-type: Update

--- a/.github/workflows/daily-6.0.yml
+++ b/.github/workflows/daily-6.0.yml
@@ -23,3 +23,10 @@ jobs:
     - name: Build and upload daily .iso
       run: |
         ./workflows.sh etc/terraform-daily-6.0-azure.conf "${{ secrets.key }}" "${{ secrets.secret }}" "${{ secrets.endpoint }}" "${{ secrets.bucket }}"
+
+    - name: Update Website
+      uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GIT_USER_TOKEN }}
+          repository: elementary/builds
+          event-type: update

--- a/.github/workflows/distinst-weekly.yml
+++ b/.github/workflows/distinst-weekly.yml
@@ -20,3 +20,10 @@ jobs:
     - name: Build and upload distinst .iso
       run: |
         ./workflows.sh etc/terraform-daily-5.1-distinst-azure.conf "${{ secrets.key }}" "${{ secrets.secret }}" "${{ secrets.endpoint }}" "${{ secrets.bucket }}"
+
+    - name: Update Website
+      uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GIT_USER_TOKEN }}
+          repository: elementary/builds
+          event-type: update

--- a/.github/workflows/distinst-weekly.yml
+++ b/.github/workflows/distinst-weekly.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           token: ${{ secrets.GIT_USER_TOKEN }}
           repository: elementary/builds
-          event-type: update
+          event-type: Update


### PR DESCRIPTION
This makes the `os` repository dispatch a custom `update` event to the `builds` repository when an iso is pushed. It's _probably_ better and faster than just cron jobs