### PR TITLE
remove double space in upload.sh

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -24,7 +24,7 @@ echo -e "
 # UPLOAD ISO #
 #------------#
 "
-# install boto, which can  be fetched via pip
+# install boto, which can be fetched via pip
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 python3 get-pip.py
 pip install boto3


### PR DESCRIPTION
When I looked through the scripts, I noticed there's an extra space character in a comment in the upload.sh script.
It's a small detail, but it's always something that bothers me once I've spotted it.