### PR TITLE
Install epiphany as systemwide flatpak

### DIFF
--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -12,6 +12,8 @@ allow org.gnome.Epiphany/*/stable
 allow org.gnome.Epiphany.*/*/stable
 EOF
 
+chmod -R 644 /etc/flatpak
+
 flatpak remote-add --if-not-exists --filter=/etc/flatpak/epiphany.filter flathub https://flathub.org/repo/flathub.flatpakrepo
 
 flatpak install -y flathub org.gnome.Epiphany

--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -1,6 +1,17 @@
 #!/bin/sh
 # Description: Add flatpak remote and install systemwide flatpaks
 
-flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+mkdir -p /etc/flatpak
+
+cat << EOF > /etc/flatpak/epiphany.filter
+# Only allow Epiphany and its dependencies
+deny *
+allow runtime/org.freedesktop.*
+allow runtime/org.gnome.*
+allow org.gnome.Epiphany/*/stable
+allow org.gnome.Epiphany.*/*/stable
+EOF
+
+flatpak remote-add --if-not-exists --filter=/etc/flatpak/epiphany.filter flathub https://flathub.org/repo/flathub.flatpakrepo
 
 flatpak install -y flathub org.gnome.Epiphany

--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Description: Add flatpak remote and install systemwide flatpaks
+
+flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+flatpak install -y flathub org.gnome.Epiphany


### PR DESCRIPTION
This has the caveats mentioned on the call:

- flathub gets included so needs filtering
- will probably be adwaita
- will need to figure how to set it as default browser

Additionally, this will only work for the amd64 iso for now. I need to rework the pinebook build scripts slightly to ensure the same hooks get run for both.