### PR TITLE
pinebookpro: Run same hooks as amd64 iso

### DIFF
--- a/.github/workflows/daily-6.0-pinebookpro.yml
+++ b/.github/workflows/daily-6.0-pinebookpro.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - pinebookpro-hooks
       - github-update
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/daily-6.0-pinebookpro.yml
+++ b/.github/workflows/daily-6.0-pinebookpro.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - pinebookpro-hooks
       - github-update
   schedule:
     - cron: "0 0 * * *"

--- a/build-pinebookpro.sh
+++ b/build-pinebookpro.sh
@@ -197,6 +197,15 @@ EOF
 chmod +x ${work_dir}/build-initramfs
 LANG=C chroot ${work_dir} /build-initramfs
 
+mkdir ${work_dir}/hooks
+cp ${rootdir}/etc/config/hooks/live/*.chroot ${work_dir}/hooks
+
+for f in ${work_dir}/hooks/*
+do
+    base=`basename ${f}`
+    LANG=C chroot ${work_dir} "/hooks/${base}"
+done
+
 # Calculate the space to create the image.
 root_size=$(du -s -B1K ${work_dir} | cut -f1)
 raw_size=$(($((${free_space}*1024))+${root_size}))
@@ -292,15 +301,6 @@ w- /sys/devices/system/cpu/cpufreq/policy0/scaling_min_freq - - - - 1200000
 w- /sys/devices/system/cpu/cpufreq/policy4/scaling_min_freq - - - - 1008000
 w- /sys/class/devfreq/ff9a0000.gpu/min_freq - - - - 600000000
 EOF
-
-mkdir ${work_dir}/hooks
-cp ${rootdir}/etc/config/hooks/live/*.chroot ${work_dir}/hooks
-
-for f in ${work_dir}/hooks/*
-do
-    base=`basename ${f}`
-    LANG=C chroot ${work_dir} "/hooks/${base}"
-done
 
 umount ${work_dir}/dev/pts
 umount ${work_dir}/dev/

--- a/build-pinebookpro.sh
+++ b/build-pinebookpro.sh
@@ -206,6 +206,8 @@ do
     LANG=C chroot ${work_dir} "/hooks/${base}"
 done
 
+rm -r "${work_dir}/hooks"
+
 # Calculate the space to create the image.
 root_size=$(du -s -B1K ${work_dir} | cut -f1)
 raw_size=$(($((${free_space}*1024))+${root_size}))

--- a/build-pinebookpro.sh
+++ b/build-pinebookpro.sh
@@ -299,7 +299,7 @@ cp ${rootdir}/etc/config/hooks/live/*.chroot ${work_dir}/hooks
 for f in ${work_dir}/hooks/*
 do
     base=`basename ${f}`
-    LANG=C chroot ${workdir} /hooks/${base}
+    LANG=C chroot ${work_dir} "/hooks/${base}"
 done
 
 umount ${work_dir}/dev/pts

--- a/build-pinebookpro.sh
+++ b/build-pinebookpro.sh
@@ -293,30 +293,14 @@ w- /sys/devices/system/cpu/cpufreq/policy4/scaling_min_freq - - - - 1008000
 w- /sys/class/devfreq/ff9a0000.gpu/min_freq - - - - 600000000
 EOF
 
-cat << EOF > ${work_dir}/cleanup
-#!/bin/bash
+mkdir ${work_dir}/hooks
+cp ${rootdir}/etc/config/hooks/live/*.chroot ${work_dir}/hooks
 
-apt-get install --no-install-recommends -f -q -y git
-git clone --depth 1 https://github.com/elementary/seeds.git --single-branch --branch $codename
-git clone --depth 1 https://github.com/elementary/platform.git --single-branch --branch $codename
-for package in \$(cat 'platform/blacklist' 'seeds/blacklist' | grep -v '#'); do
-    apt-get autoremove --purge -f -q -y "\$package"
+for f in ${work_dir}/hooks/*
+do
+    base=`basename ${f}`
+    LANG=C chroot ${workdir} /hooks/${base}
 done
-apt-get autoremove --purge -f -q -y git
-rm -R ../seeds ../platform
-rm -rf /root/.bash_history
-apt-get clean
-rm -f /0
-rm -f /hs_err*
-rm -f /cleanup
-rm -f /usr/bin/qemu*
-rm -f /var/lib/apt/lists/*_Packages
-rm -f /var/lib/apt/lists/*_Sources
-rm -f /var/lib/apt/lists/*_Translation-*
-EOF
-
-chmod +x ${work_dir}/cleanup
-LANG=C chroot ${work_dir} /cleanup
 
 umount ${work_dir}/dev/pts
 umount ${work_dir}/dev/


### PR DESCRIPTION
Instead of duplicating code to remove unwanted packages and cleanup, run the same scripts from the `hooks` directory that do this and install Flatpak Epiphany.

This will bring the pinebookpro images to the same feature parity as the amd64 ones regarding Flatpak Epiphany.

I have tested that this produces working images.