### PR TITLE
Don't install flatpak epiphany on hera

### DIFF
--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -1,6 +1,12 @@
 #!/bin/sh
 # Description: Add flatpak remote and install systemwide flatpaks
 
+dist="$(lsb_release -c -s -u 2>&1)"||dist="$(lsb_release -c -s)"
+
+if [ "$dist" = "bionic" ] ; then
+    exit 0
+fi
+
 mkdir -p /etc/flatpak
 
 cat << EOF > /etc/flatpak/epiphany.filter


### PR DESCRIPTION
Since we use these hooks for all of our images, we have to special case bionic/hera to make sure we don't install flatpak epiphany.