### PR TITLE
Separate HWE packages and enable for odin

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -4,12 +4,14 @@ set -e
 
 . ./terraform.conf
 
-# HWE starts with y, Y or 1?
-if [ "$HWE" = "yes" ]; then
+if [ "$HWE_KERNEL" = "yes" ]; then
     KERNEL_FLAVORS="generic-hwe-${BASEVERSION}"
-    XORG_HWE="xserver-xorg-hwe-${BASEVERSION}"
 else
     KERNEL_FLAVORS="generic"
+fi
+
+if [ "$HWE_X11" = "yes" ]; then
+    XORG_HWE="xserver-xorg-hwe-${BASEVERSION}"
 fi
 
 lb config noauto \

--- a/etc/terraform-daily-5.1-azure.conf
+++ b/etc/terraform-daily-5.1-azure.conf
@@ -23,7 +23,8 @@ NAME="elementary OS"
 MIRROR_URL="http://azure.archive.ubuntu.com/ubuntu/"
 
 # use HWE kernel and packages?
-HWE="yes"
+HWE_KERNEL="yes"
+HWE_X11="yes"
 
 # use appcenter ppa
 INCLUDE_APPCENTER="yes"

--- a/etc/terraform-daily-5.1-distinst-azure.conf
+++ b/etc/terraform-daily-5.1-distinst-azure.conf
@@ -23,7 +23,8 @@ NAME="elementary OS"
 MIRROR_URL="http://azure.archive.ubuntu.com/ubuntu/"
 
 # use HWE kernel and packages?
-HWE="yes"
+HWE_KERNEL="yes"
+HWE_X11="yes"
 
 # use appcenter ppa
 INCLUDE_APPCENTER="yes"

--- a/etc/terraform-daily-6.0-azure.conf
+++ b/etc/terraform-daily-6.0-azure.conf
@@ -23,7 +23,8 @@ NAME="elementary OS"
 MIRROR_URL="http://azure.archive.ubuntu.com/ubuntu/"
 
 # use HWE kernel and packages?
-HWE=""
+HWE_KERNEL="yes"
+HWE_X11="no"
 
 # use appcenter ppa
 INCLUDE_APPCENTER=""

--- a/etc/terraform-stable-azure.conf
+++ b/etc/terraform-stable-azure.conf
@@ -23,7 +23,8 @@ NAME="elementary OS"
 MIRROR_URL="http://azure.archive.ubuntu.com/ubuntu/"
 
 # use HWE kernel and packages?
-HWE="yes"
+HWE_KERNEL="yes"
+HWE_X11="yes"
 
 # use appcenter ppa
 INCLUDE_APPCENTER="yes"

--- a/etc/terraform.conf
+++ b/etc/terraform.conf
@@ -23,7 +23,8 @@ NAME="elementary OS"
 MIRROR_URL="http://azure.archive.ubuntu.com/ubuntu/"
 
 # use HWE kernel and packages?
-HWE="yes"
+HWE_KERNEL="yes"
+HWE_X11="yes"
 
 # use appcenter ppa
 INCLUDE_APPCENTER="yes"


### PR DESCRIPTION
Fixes #445 

The previous scripts assumed that if we were building a HWE image, there would also be a HWE version of XOrg. This doesn't seem to be true for focal (yet?), so we need to separate out the two config options.

This also enables installation of the HWE kernel for Odin. I've tested an iso built with these changes, and verified that it boots successfully with the 5.8 kernel.