### PR TITLE
rpi: Bluetooth fixes

### DIFF
--- a/build-rpi.sh
+++ b/build-rpi.sh
@@ -107,7 +107,10 @@ cat << EOF > elementary-$architecture/hardware
 # we'll recreate it on the actual partition later
 mkdir -p /boot/firmware
 
-apt-get --yes install linux-image-raspi linux-firmware-raspi2
+apt-get --yes install linux-image-raspi linux-firmware-raspi2 pi-bluetooth
+
+# Symlink to workaround bug with Bluetooth driver looking in the wrong place for firmware
+sudo ln -s /lib/firmware /etc/firmware
 
 rm -rf /boot/firmware
 

--- a/build-rpi.sh
+++ b/build-rpi.sh
@@ -110,7 +110,7 @@ mkdir -p /boot/firmware
 apt-get --yes install linux-image-raspi linux-firmware-raspi2 pi-bluetooth
 
 # Symlink to workaround bug with Bluetooth driver looking in the wrong place for firmware
-sudo ln -s /lib/firmware /etc/firmware
+ln -s /lib/firmware /etc/firmware
 
 rm -rf /boot/firmware
 


### PR DESCRIPTION
Fixes #457 

We were missing a package, and there's a bug in 20.04 (which doesn't officially support the Pi 400) that means we have to symlink the firmware directory so that the Bluetooth driver looks in the right place for it instead of in `/etc/firmware` which doesn't exist.