### PR TITLE
README: Cleanup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,31 +23,23 @@
 
 As elementary OS is built with the Debian version of `live-build`, not the Ubuntu patched version, it's easiest to build an elementary .iso in a Debian VM or container. This prevents messing up your host system too.
 
-The following example uses Docker and assumes you have Docker correctly installed and set up:
+The following examples assume you have Docker correctly installed and set up, and that your current working directory is this repo. When done, your image will be in the `builds` folder.
 
- 1) Clone this project & `cd` into it:
+### 64-bit AMD/Intel
 
-    ```
-    git clone https://github.com/elementary/os && cd os
-    ```
+Configure the channel in the `etc/terraform.conf` (stable, daily), then run:
 
- 2) Configure the channel in the `etc/terraform.conf` (stable, daily).
-
- 3) Run the build:
-
-    ```
-    docker run --privileged -i -v /proc:/proc \
-        -v ${PWD}:/working_dir \
-        -w /working_dir \
-        debian:latest \
-        /bin/bash -s etc/terraform.conf < build.sh
-    ```
-
- 4) When done, your image will be in the `builds` folder.
-
-## Raspberry Pi 4
-
+```sh
+docker run --privileged -i -v /proc:/proc \
+    -v ${PWD}:/working_dir \
+    -w /working_dir \
+    debian:latest \
+    /bin/bash -s etc/terraform.conf < build.sh
 ```
+
+### Raspberry Pi 4
+
+```sh
 docker run --privileged -i -v /proc:/proc \
     -v ${PWD}:/working_dir \
     -w /working_dir \
@@ -55,6 +47,15 @@ docker run --privileged -i -v /proc:/proc \
     ./build-rpi.sh
 ```
 
+### Pinebook Pro
+
+```sh
+docker run --privileged -i -v /proc:/proc \
+    -v ${PWD}:/working_dir \
+    -w /working_dir \
+    debian:unstable \
+    ./build-pinebookpro.sh
+```
 
 ## Further Information
 


### PR DESCRIPTION
- Adds Pinebook Pro
- Simplifies a bit
- Splits amd64 builds out into an equal subsection with the relevant instructions there