### PR TITLE
Add filtered Flathub for FreeDesktop extensions

### DIFF
--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -3,6 +3,12 @@
 
 mkdir -p /etc/flatpak
 
-flatpak remote-add --if-not-exists --system appcenter https://flatpak.elementary.io/repo.flatpakrepo
+cat << EOF > /etc/flatpak/freedesktop.filter
+# Only allow FreeDesktop extensions
+deny *
+allow runtime/org.freedesktop.*
+EOF
 
-flatpak install -y appcenter io.elementary.calculator io.elementary.screenshot org.gnome.Epiphany org.gnome.Evince
+flatpak remote-add --if-not-exists --system --filter=/etc/flatpak/freedesktop.filter freedesktop https://flathub.org/repo/flathub.flatpakrepo
+flatpak remote-add --if-not-exists --system appcenter https://flatpak.elementary.io/repo.flatpakrepo
+flatpak install --system -y appcenter io.elementary.calculator io.elementary.screenshot org.gnome.Epiphany org.gnome.Evince


### PR DESCRIPTION
Like how we used to for Epiphany, but only allowing `org.freedesktop.*` runtimes/extensions. Also ensures we use `--system` with each command to be explicit about the intent.

I named the remote `freedesktop` since that's what it's filtered down to. I'm not sure if we want to do that or just call it `flathub`, but I kind of like naming it what it's filtered to.