### PR TITLE
Hooks: Install Tasks as Flatpak

### DIFF
--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -15,5 +15,6 @@ flatpak install --system -y appcenter \
     io.elementary.calculator \
     io.elementary.camera \
     io.elementary.screenshot \
+    io.elementary.tasks \
     org.gnome.Epiphany \
     org.gnome.Evince


### PR DESCRIPTION
Depends on https://github.com/elementary/tasks/runs/2586598768 passing and Tasks being installable from the Flatpak repo