### PR TITLE
Hooks: Install Mail as Flatpak

### DIFF
--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -14,6 +14,7 @@ flatpak remote-add --if-not-exists --system appcenter https://flatpak.elementary
 flatpak install --system -y appcenter \
     io.elementary.calculator \
     io.elementary.camera \
+    io.elementary.mail \
     io.elementary.screenshot \
     org.gnome.Epiphany \
     org.gnome.Evince


### PR DESCRIPTION
Depends on https://github.com/elementary/mail/runs/2586738375 passing and Mail being installable from the Flatpak repo.