### PR TITLE
Flatpak: Specify `master` for all missing branches

### DIFF
--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -14,10 +14,10 @@ flatpak remote-add --if-not-exists --system appcenter https://flatpak.elementary
 flatpak install --system -y appcenter \
     io.elementary.calculator//master \
     io.elementary.camera//daily \
-    io.elementary.screenshot \
-    io.elementary.tasks \
+    io.elementary.screenshot//master \
+    io.elementary.tasks//master \
     org.gnome.Epiphany//daily \
-    org.gnome.Evince
+    org.gnome.Evince//master
 
 # Required for Epiphany
 flatpak install --system -y freedesktop org.freedesktop.Platform.GL.default//20.08


### PR DESCRIPTION
In case we start building any more of them into a `stable` branch, this will prevent #497 from happening again.