### PR TITLE
Flatpak: point first-party apps to stable

### DIFF
--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -12,10 +12,10 @@ EOF
 flatpak remote-add --if-not-exists --system --filter=/etc/flatpak/freedesktop.filter freedesktop https://flathub.org/repo/flathub.flatpakrepo
 flatpak remote-add --if-not-exists --system appcenter https://flatpak.elementary.io/repo.flatpakrepo
 flatpak install --system -y appcenter \
-    io.elementary.calculator//master \
-    io.elementary.camera//daily \
-    io.elementary.screenshot//master \
-    io.elementary.tasks//master \
+    io.elementary.calculator//stable \
+    io.elementary.camera//stable \
+    io.elementary.screenshot//stable \
+    io.elementary.tasks//stable \
     org.gnome.Epiphany//daily \
     org.gnome.Evince//master
 


### PR DESCRIPTION
Fixes #506. Epiphany and Evince omitted for now because we don't have them available in a stable branch. See https://github.com/elementary/browser/issues/34 and https://github.com/elementary/evince/issues/13.