### PR TITLE
Flatpak: include Epiphany from stable

### DIFF
--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -16,7 +16,7 @@ flatpak install --system -y appcenter \
     io.elementary.camera//stable \
     io.elementary.screenshot//stable \
     io.elementary.tasks//stable \
-    org.gnome.Epiphany//daily \
+    org.gnome.Epiphany//stable \
     org.gnome.Evince//stable
 
 # Required for Epiphany


### PR DESCRIPTION
Need to make sure this passes first https://github.com/elementary/browser/runs/3226972932 (and Epiphany is in the AppCenter remote)