### PR TITLE
Allow live-build to remove protected pkgs in iso bootloader stage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,8 @@ apt-get install -y live-build patch ubuntu-keyring
 # https://salsa.debian.org/live-team/live-build/merge_requests/31
 patch -d /usr/lib/live/build/ < live-build-fix-syslinux.patch
 
+patch -d /usr/lib/live/build/ < live-build-fix-shim-remove.patch
+
 # TODO: Remove this once debootstrap 1.0.117 or newer is released and available:
 # https://salsa.debian.org/installer-team/debootstrap/blob/master/debian/changelog
 ln -sfn /usr/share/debootstrap/scripts/gutsy /usr/share/debootstrap/scripts/focal

--- a/live-build-fix-shim-remove.patch
+++ b/live-build-fix-shim-remove.patch
@@ -1,0 +1,18 @@
+--- /usr/lib/live/build/binary_grub-efi	2019-03-11 10:05:40.000000000 +0000
++++ /usr/lib/live/build/binary_grub-efi_v2	2021-08-04 13:37:20.064547041 +0000
+@@ -267,8 +267,12 @@
+ 		# Saving cache
+ 		Save_cache cache/packages.binary
+
+-		# Removing depends
+-		Remove_package
++		# Removing depends, some bootloader packages are marked as Protected/Important
++		# in Ubuntu, so temporarily add an apt flag to allow them to be removed
++		PRE_APT_OPTIONS="${APT_OPTIONS}"
++		APT_OPTIONS="${APT_OPTIONS} --allow-remove-essential"
++		Remove_package
++		APT_OPTIONS="${PRE_APT_OPTIONS}"
+ 		;;
+
+ 	false)
+


### PR DESCRIPTION
Fixes #514 

I've tested that this is enough to get the RC image building locally.

The `shim-signed` package from Ubuntu was updated 2 days ago to include some flags in the debian control file to prevent accidental removal of the package. During the phase of the build that was failing, live-build temporarily installs grub and the shim to make the boot sector of the iso image, and then tries to remove them again afterwards to clean up after itself. Since Ubuntu updated `shim-signed`, it wasn't able to remove it anymore, without an additional flag.

I'll get this proposed as a patch upstream and then we can add a comment in here with a link to the PR. But I've proposed here first so we can at least get going with building an RC image.