### PR TITLE
Leave comment about live-build shim fix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,9 @@ apt-get install -y live-build patch ubuntu-keyring
 # https://salsa.debian.org/live-team/live-build/merge_requests/31
 patch -d /usr/lib/live/build/ < live-build-fix-syslinux.patch
 
+# TODO: This patch was submitted upstream at:
+# https://salsa.debian.org/live-team/live-build/-/merge_requests/255
+# This can be removed when our Debian container has a version containing this fix
 patch -d /usr/lib/live/build/ < live-build-fix-shim-remove.patch
 
 # TODO: Remove this once debootstrap 1.0.117 or newer is released and available:


### PR DESCRIPTION
Patch has been approved upstream, just waiting on CI:
https://salsa.debian.org/live-team/live-build/-/merge_requests/255

Leave a note for ourselves in the future that we can remove this once there's a stable release incorporating the fix.