### PR TITLE
Experiment with some faster timeouts on the apt mirrors

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -34,7 +34,7 @@ lb config noauto \
     --mirror-binary "mirror://mirrors.ubuntu.com/mirrors.txt" \
     --parent-mirror-binary "mirror://mirrors.ubuntu.com/mirrors.txt" \
     --keyring-packages ubuntu-keyring \
-    --apt-options "--yes --option Acquire::Retries=5 --option Acquire::http::Timeout=100" \
+    --apt-options "--yes --option Acquire::Retries=2 --option Acquire::http::Timeout=45" \
     --cache-packages false \
     --cache-stages false \
     --uefi-secure-boot enable \


### PR DESCRIPTION
Probably worth waiting until after we've got an RC image to merge this in case it breaks it again :sweat_smile: 

I remember putting this in place to solve some build failures I was seeing in GitHub Actions that I wasn't getting locally, probably due to my geographic location vs. where the GitHub builder was and which mirrors it was choosing.

It significantly slows down the build, but there was never any real science behind the numbers I chose. So lets try something less (but still more than the defaults), and see if we gain some speed without getting random failures again.