### PR TITLE
Flatpak: Use `--noninteractive` flag

### DIFF
--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -11,7 +11,7 @@ EOF
 
 flatpak remote-add --if-not-exists --system --filter=/etc/flatpak/freedesktop.filter freedesktop https://flathub.org/repo/flathub.flatpakrepo
 flatpak remote-add --if-not-exists --system appcenter https://flatpak.elementary.io/repo.flatpakrepo
-flatpak install --system -y appcenter \
+flatpak install --system --noninteractive appcenter \
     io.elementary.calculator//stable \
     io.elementary.camera//stable \
     org.gnome.Epiphany//stable \

--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -18,4 +18,4 @@ flatpak install --system -y appcenter \
     org.gnome.Evince//stable
 
 # Required for Epiphany
-flatpak install --system -y freedesktop org.freedesktop.Platform.GL.default//20.08
+flatpak install --system --noninteractive freedesktop org.freedesktop.Platform.GL.default//20.08


### PR DESCRIPTION
Does the same as `-y` and also reduces the "pretty" output that ends up clogging up logs. For prior art, see e.g.: https://github.com/elementary/capnet-assist/blob/4417b38e16cff8bbc948bd0d44ea1fb694d6bf14/debian/postinst#L6