### PR TITLE
Bump FD.o GL to 21.08

### DIFF
--- a/etc/config/hooks/live/001-install-flatpaks.chroot
+++ b/etc/config/hooks/live/001-install-flatpaks.chroot
@@ -18,4 +18,4 @@ flatpak install --system --noninteractive appcenter \
     org.gnome.Evince//stable
 
 # Required for Epiphany
-flatpak install --system --noninteractive freedesktop org.freedesktop.Platform.GL.default//20.08
+flatpak install --system --noninteractive freedesktop org.freedesktop.Platform.GL.default//21.08


### PR DESCRIPTION
This should solve page crashes in the live environment with Epiphany now that we're shipping 41

I've confirmed that this fixes Ephy crashes in a fresh install of OS 6 daily