### PR TITLE
Build OSTree based images

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,3 @@ This step can take up to an hour, depending on the hardware. The most time-consu
 ### build-ostree-image.sh
 
 This script is based on [deb-ostree-builder/create-deployment at 15d8fe91af21592bf323fbf9aaf03b86bbe7359d - dbnicholson/deb-ostree-builder](https://github.com/dbnicholson/deb-ostree-builder/blob/15d8fe91af21592bf323fbf9aaf03b86bbe7359d/create-deployment). Only variables were renamed and paths were adjusted.
-
-```
-error: Bootloader write config: Failed to execute child process ?grub2-mkconfig? (No such file or directory)
-```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing
+
+## OSTree based images
+
+> OSTree is an upgrade system for Linux-based operating systems that performs atomic upgrades of complete filesystem trees. It is not a package system; rather, it is intended to complement them. A primary model is composing packages on a server, and then replicating them to clients. The underlying architecture might be summarized as “git for operating system binaries”. It operates in userspace, and will work on top of any Linux filesystem. At its core is a git-like content-addressed object store with branches (or “refs”) to track meaningful filesystem trees within the store. Similarly, one can check out or commit to these branches.
+
+Source: https://ostreedev.github.io/ostree/
+
+References:
+- [Debian meets OSTree and Flatpak, a case study: Endless OS - YouTube](https://www.youtube.com/watch?v=XNDlCADG4ws)
+
+### build-ostree-repository.sh
+
+The required steps are performed in Docker as for the other build scripts.
+
+First, some variables are declared. Most of them should be self-explanatory. `flatpak_architecture` is used to later create an OSTree branch that follows the Flatpak naming scheme:
+
+- io.elementary.Platform/x86_64/6
+- io.elementary.Sdk/x86_64/6.1
+
+Similar to the ARM based images, a minimal Ubuntu system is created via `debootstrap` at the beginning. To this the extended Ubuntu repositories are added.
+
+To be able to create an OSTree compatible initramfs later, we use [dracut](https://dracut.wiki.kernel.org/index.php/Main_Page). Since the initramfs must not be host-specific, dracut must be configured accordingly.
+
+After that, elementary OS specific configurations are done and the base packages are installed. These steps should also be familiar from the ARM based build scripts.
+
+Next, the rootfs created with `debootstrap` is modified to make it OSTree compatible. These steps are based on [deb-ostree-builder/deb-ostree-builder at 15d8fe91af21592bf323fbf9aaf03b86bbe7359d · dbnicholson/deb-ostree-builder](https://github.com/dbnicholson/deb-ostree-builder/blob/15d8fe91af21592bf323fbf9aaf03b86bbe7359d/deb-ostree-builder).
+
+Finally, the modified rootfs is ready to be put into an OSTree repository. If necessary, the repository is created first. Then a commit is generated and finally the repository summary is updated.
+
+This step can take up to an hour, depending on the hardware. The most time-consuming step is the creation of the OSTree. Rebuilding should be faster.
+
+### build-ostree-image.sh
+
+This script is based on [deb-ostree-builder/create-deployment at 15d8fe91af21592bf323fbf9aaf03b86bbe7359d - dbnicholson/deb-ostree-builder](https://github.com/dbnicholson/deb-ostree-builder/blob/15d8fe91af21592bf323fbf9aaf03b86bbe7359d/create-deployment). Only variables were renamed and paths were adjusted.
+
+```
+error: Bootloader write config: Failed to execute child process ?grub2-mkconfig? (No such file or directory)
+```

--- a/README.md
+++ b/README.md
@@ -57,6 +57,30 @@ docker run --privileged -i -v /proc:/proc \
     ./build-pinebookpro.sh
 ```
 
+### OSTree based image
+
+For easier debugging, the creation of the repository and the image is currently split into 2 steps.
+
+#### repository
+
+```sh
+docker run --privileged -i -v /proc:/proc \
+    -v ${PWD}:/working_dir \
+    -w /working_dir \
+    debian:unstable \
+    ./build-ostree-repository.sh
+```
+
+#### image
+
+```sh
+docker run --privileged -i -v /proc:/proc \
+    -v ${PWD}:/working_dir \
+    -w /working_dir \
+    debian:unstable \
+    ./build-ostree-image.sh
+```
+
 ## Further Information
 
 More information about the concepts behind `live-build` and the technical decisions made to arrive at this set of tools to build an .iso can be found [on the wiki](https://github.com/elementary/os/wiki/Building-iso-Images).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For easier debugging, the creation of the repository and the image is currently 
 docker run --privileged -i -v /proc:/proc \
     -v ${PWD}:/working_dir \
     -w /working_dir \
-    debian:unstable \
+    ubuntu:latest \
     ./build-ostree-repository.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker run --privileged -i -v /proc:/proc \
 docker run --privileged -i -v /proc:/proc \
     -v ${PWD}:/working_dir \
     -w /working_dir \
-    debian:unstable \
+    fedora:latest \
     ./build-ostree-image.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ For easier debugging, the creation of the repository and the image is currently 
 
 ```sh
 docker run --privileged -i -v /proc:/proc \
+    -v /dev:/dev \
     -v ${PWD}:/working_dir \
     -w /working_dir \
     ubuntu:latest \
@@ -75,9 +76,10 @@ docker run --privileged -i -v /proc:/proc \
 
 ```sh
 docker run --privileged -i -v /proc:/proc \
+    -v /dev:/dev \
     -v ${PWD}:/working_dir \
     -w /working_dir \
-    debian:unstable \
+    ubuntu:latest \
     ./build-ostree-image.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker run --privileged -i -v /proc:/proc \
 docker run --privileged -i -v /proc:/proc \
     -v ${PWD}:/working_dir \
     -w /working_dir \
-    fedora:latest \
+    debian:unstable \
     ./build-ostree-image.sh
 ```
 

--- a/build-ostree-image.sh
+++ b/build-ostree-image.sh
@@ -8,6 +8,9 @@ export version=7
 export flatpak_architecture=x86_64
 export ostree_branch="io.elementary.desktop/${flatpak_architecture}/${version}"
 
+export LC_ALL=C
+export DEBIAN_FRONTEND=noninteractive
+
 builddir=artifacts/${ostree_branch}
 ostree_repo_dir=artifacts/ostree
 

--- a/build-ostree-image.sh
+++ b/build-ostree-image.sh
@@ -24,7 +24,8 @@ ostree_sysroot_repopath=${ostree_sysroot}/ostree/repo
 ostree_sysroot_boot=${ostree_sysroot}/boot
 
 # Install dependencies in host system
-dnf install -y ostree grub2
+apt-get update
+apt-get install -y --no-install-recommends ostree uuid-runtime ostree-boot grub-pc-bin
 
 ostree admin init-fs "${ostree_sysroot}"
 ostree admin --sysroot="${ostree_sysroot}" os-init ${ostree_os_name}

--- a/build-ostree-image.sh
+++ b/build-ostree-image.sh
@@ -7,6 +7,7 @@ set -e
 export version=7
 export flatpak_architecture=x86_64
 export ostree_branch="io.elementary.desktop/${flatpak_architecture}/${version}"
+export bootloader_backend=none
 
 export LC_ALL=C
 export DEBIAN_FRONTEND=noninteractive
@@ -32,6 +33,7 @@ apt-get install -y --no-install-recommends ostree uuid-runtime ostree-boot grub-
 
 ostree admin init-fs "${ostree_sysroot}"
 ostree admin --sysroot="${ostree_sysroot}" os-init ${ostree_os_name}
+ostree config --repo ${ostree_sysroot_repopath} set sysroot.bootloader ${bootloader_backend}
 ostree --repo="${ostree_sysroot_repopath}" remote add ${ostree_os_name} ${ostree_url} \
   ${ostree_branch}
 ostree --repo="${ostree_sysroot_repopath}" pull-local --disable-fsync \

--- a/build-ostree-image.sh
+++ b/build-ostree-image.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Based on https://github.com/dbnicholson/deb-ostree-builder/blob/15d8fe91af21592bf323fbf9aaf03b86bbe7359d/create-deployment
+
+# fail on first error
+set -e
+
+export version=6
+export flatpak_architecture=x86_64
+export ostree_branch="io.elementary.desktop/${flatpak_architecture}/${version}"
+
+builddir=artifacts/${ostree_branch}
+ostree_repo_dir=artifacts/ostree
+
+# Where the checkout of the tree goes
+ostree_sysroot=$(mktemp -d -p artifacts ostree-deploy.XXXXXXXXXX)
+
+# Name of the OS for ostree deployment
+ostree_os_name=elementary
+
+# The ostree remote URL in installed configuration
+ostree_url=https://ostree.elementary.io/
+
+ostree_sysroot_repopath=${ostree_sysroot}/ostree/repo
+ostree_sysroot_boot=${ostree_sysroot}/boot
+
+# Install dependencies in host system
+apt-get update
+apt-get install -y --no-install-recommends ostree uuid-runtime ostree-boot grub-pc-bin
+
+ostree admin init-fs "${ostree_sysroot}"
+ostree admin --sysroot="${ostree_sysroot}" os-init ${ostree_os_name}
+ostree --repo="${ostree_sysroot_repopath}" remote add ${ostree_os_name} ${ostree_url} \
+  ${ostree_branch}
+ostree --repo="${ostree_sysroot_repopath}" pull-local --disable-fsync \
+  --remote=${ostree_os_name} ${ostree_repo_dir} ${ostree_branch}
+
+# Basic bootloader setup
+if [[ "${flatpak_architecture}" == "armhf" ]]; then
+  mkdir -p "${ostree_sysroot_boot}"/loader.0
+  ln -s loader.0 "${ostree_sysroot_boot}"/loader
+  # Empty uEnv.txt otherwise ostree gets upset
+  > "${ostree_sysroot_boot}"/loader/uEnv.txt
+  ln -s loader/uEnv.txt "${ostree_sysroot_boot}"/uEnv.txt
+else
+  # Assume grub for all other architectures
+  mkdir -p "${ostree_sysroot_boot}"/grub
+  # This is entirely using Boot Loader Spec (bls). A more general
+  # grub.cfg is likely needed
+  cat > "${ostree_sysroot_boot}"/grub/grub.cfg <<"EOF"
+insmod blscfg
+bls_import
+set default='0'
+EOF
+fi
+
+# Deploy with root=UUID random
+uuid=$(uuidgen)
+kargs=(--karg=root=UUID=${uuid} --karg=rw --karg=splash \
+    --karg=plymouth.ignore-serial-consoles --karg=quiet)
+ostree admin --sysroot="${ostree_sysroot}" deploy \
+  --os=${ostree_os_name} "${kargs[@]}" \
+  ${ostree_os_name}:${ostree_branch}
+
+# Now $ostree_sysroot is ready to be written to some disk

--- a/build-ostree-image.sh
+++ b/build-ostree-image.sh
@@ -24,8 +24,7 @@ ostree_sysroot_repopath=${ostree_sysroot}/ostree/repo
 ostree_sysroot_boot=${ostree_sysroot}/boot
 
 # Install dependencies in host system
-apt-get update
-apt-get install -y --no-install-recommends ostree uuid-runtime ostree-boot grub-pc-bin
+dnf install -y ostree grub2
 
 ostree admin init-fs "${ostree_sysroot}"
 ostree admin --sysroot="${ostree_sysroot}" os-init ${ostree_os_name}

--- a/build-ostree-image.sh
+++ b/build-ostree-image.sh
@@ -4,7 +4,7 @@
 # fail on first error
 set -e
 
-export version=6
+export version=7
 export flatpak_architecture=x86_64
 export ostree_branch="io.elementary.desktop/${flatpak_architecture}/${version}"
 

--- a/build-ostree-repository.sh
+++ b/build-ostree-repository.sh
@@ -6,10 +6,10 @@ set -e
 rootdir=$(pwd)
 
 export architecture=amd64
-export channel=stable
-export codename=focal
+export channel=daily
+export codename=jammy
 export packages="systemd-sysv linux-image-generic grub-pc ostree-boot elementary-minimal elementary-desktop elementary-standard"
-export version=6
+export version=7
 export flatpak_architecture=x86_64
 export ostree_branch="io.elementary.desktop/${flatpak_architecture}/${version}"
 

--- a/build-ostree-repository.sh
+++ b/build-ostree-repository.sh
@@ -18,6 +18,9 @@ ostree_repo_dir=artifacts/ostree
 
 mkdir -p ${builddir}
 
+export LC_ALL=C
+export DEBIAN_FRONTEND=noninteractive
+
 # Install dependencies in host system
 apt-get update
 apt-get install -y --no-install-recommends ubuntu-keyring ca-certificates debootstrap ostree uuid-runtime ostree-boot grub-pc-bin
@@ -66,9 +69,6 @@ sed -i "s/@BASECODENAME/${codename}/" ${builddir}/etc/apt/sources.list.d/*.list*
 
 # Set codename in added preferences
 sed -i "s/@BASECODENAME/${codename}/" ${builddir}/etc/apt/preferences.d/*.pref*
-
-export LC_ALL=C
-export DEBIAN_FRONTEND=noninteractive
 
 mount -t proc proc ${builddir}/proc
 mount -t sysfs sys ${builddir}/sys

--- a/build-ostree-repository.sh
+++ b/build-ostree-repository.sh
@@ -1,0 +1,285 @@
+#!/bin/bash
+
+# fail on first error
+set -e
+
+rootdir=$(pwd)
+
+export architecture=amd64
+export channel=stable
+export codename=focal
+export packages="systemd-sysv linux-image-generic grub-pc ostree-boot elementary-minimal elementary-desktop elementary-standard"
+export version=6
+export flatpak_architecture=x86_64
+export ostree_branch="io.elementary.desktop/${flatpak_architecture}/${version}"
+
+builddir=artifacts/${ostree_branch}
+ostree_repo_dir=artifacts/ostree
+
+mkdir -p ${builddir}
+
+# Install dependencies in host system
+apt-get update
+apt-get install -y --no-install-recommends ubuntu-keyring ca-certificates debootstrap ostree uuid-runtime ostree-boot grub-pc-bin
+
+# Bootstrap an ubuntu minimal system
+debootstrap --arch ${architecture} ${codename} ${builddir} http://archive.ubuntu.com/ubuntu
+
+# Add the rest of the ubuntu repos
+cat << EOF > ${builddir}/etc/apt/sources.list
+deb http://archive.ubuntu.com/ubuntu ${codename} main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu ${codename}-updates main restricted universe multiverse
+EOF
+
+
+
+
+
+# Based on https://github.com/dbnicholson/deb-ostree-builder/blob/15d8fe91af21592bf323fbf9aaf03b86bbe7359d/deb-ostree-builder
+# Ensure that dracut makes generic initramfs instead of looking just
+# at the host configuration. This is also in the dracut-config-generic
+# package, but that only gets installed after dracut makes the first
+# initramfs.
+echo "Configuring dracut for generic initramfs"
+mkdir -p ${builddir}/etc/dracut.conf.d
+cat > ${builddir}/etc/dracut.conf.d/90-deb-ostree.conf <<EOF
+# Don't make host-specific initramfs
+hostonly=no
+EOF
+
+
+
+
+# Copy in the elementary PPAs/keys/apt config
+for f in "${rootdir}"/etc/config/archives/*.list; do cp -- "$f" "${builddir}/etc/apt/sources.list.d/$(basename -- "$f")"; done
+for f in "${rootdir}"/etc/config/archives/*.key; do cp -- "$f" "${builddir}/etc/apt/trusted.gpg.d/$(basename -- "$f").asc"; done
+for f in "${rootdir}"/etc/config/archives/*.pref; do cp -- "$f" "${builddir}/etc/apt/preferences.d/$(basename -- "$f")"; done
+
+# Copy in the elementary PPAs/keys/apt config
+for f in "${rootdir}"/etc/config/archives/*.list; do cp -- "$f" "${builddir}/etc/apt/sources.list.d/$(basename -- "$f")"; done
+for f in "${rootdir}"/etc/config/archives/*.key; do cp -- "$f" "${builddir}/etc/apt/trusted.gpg.d/$(basename -- "$f").asc"; done
+for f in "${rootdir}"/etc/config/archives/*.pref; do cp -- "$f" "${builddir}/etc/apt/preferences.d/$(basename -- "$f")"; done
+
+# Set codename/channel in added repos
+sed -i "s/@CHANNEL/${channel}/" ${builddir}/etc/apt/sources.list.d/*.list*
+sed -i "s/@BASECODENAME/${codename}/" ${builddir}/etc/apt/sources.list.d/*.list*
+
+# Set codename in added preferences
+sed -i "s/@BASECODENAME/${codename}/" ${builddir}/etc/apt/preferences.d/*.pref*
+
+export LC_ALL=C
+export DEBIAN_FRONTEND=noninteractive
+
+mount -t proc proc ${builddir}/proc
+mount -t sysfs sys ${builddir}/sys
+mount -o bind /dev/ ${builddir}/dev/
+mount -o bind /dev/pts ${builddir}/dev/pts
+
+# Make a third stage that installs all of the metapackages
+cat << EOF > ${builddir}/third-stage
+#!/bin/bash
+apt-get update
+apt-get --yes upgrade
+apt-get --yes install $packages
+rm -f /third-stage
+EOF
+
+chmod +x ${builddir}/third-stage
+LANG=C chroot ${builddir} /third-stage
+
+echo "elementary" > ${builddir}/etc/hostname
+
+cat << EOF > ${builddir}/etc/hosts
+127.0.0.1       elementary    localhost
+::1             localhost ip6-localhost ip6-loopback
+fe00::0         ip6-localnet
+ff00::0         ip6-mcastprefix
+ff02::1         ip6-allnodes
+ff02::2         ip6-allrouters
+EOF
+
+
+
+# TODO(meisenzahl): configure mount points based on `ostree admin deploy`
+# Configure mount points
+cat << EOF > ${builddir}/etc/fstab
+# <file system> <mount point>   <type>  <options>       <dump>  <pass>
+proc /proc proc nodev,noexec,nosuid 0  0
+LABEL=writable    /     ext4    defaults    0 0
+LABEL=system-boot       /boot/firmware  vfat    defaults        0       1
+EOF
+
+# Copy in any file overrides
+cp -r "${rootdir}"/etc/config/includes.chroot/* ${builddir}/
+
+mkdir ${builddir}/hooks
+cp "${rootdir}"/etc/config/hooks/live/*.chroot ${builddir}/hooks
+
+hook_files="${builddir}/hooks/*"
+for f in $hook_files
+do
+    base=$(basename "${f}")
+    LANG=C chroot ${builddir} "/hooks/${base}"
+done
+
+rm -r "${builddir}/hooks"
+
+umount ${builddir}/dev/pts
+umount ${builddir}/dev/
+umount ${builddir}/sys
+umount ${builddir}/proc
+
+
+
+
+
+# Based on https://github.com/dbnicholson/deb-ostree-builder/blob/15d8fe91af21592bf323fbf9aaf03b86bbe7359d/deb-ostree-builder
+# Cleanup cruft
+echo "Preparing system for OSTree"
+rm -rf \
+   "${builddir}"/boot/*.bak \
+   "${builddir}"/etc/apt/sources.list~ \
+   "${builddir}"/etc/apt/trusted.gpg~ \
+   "${builddir}"/etc/{passwd,group,shadow,gshadow}- \
+   "${builddir}"/var/cache/debconf/*-old \
+   "${builddir}"/var/lib/dpkg/*-old \
+   "${builddir}"/boot/{initrd.img,vmlinuz} \
+   "${builddir}"/{initrd.img,vmlinuz}{,.old}
+
+# Remove dbus machine ID cache (makes each system unique)
+rm -f "${builddir}"/var/lib/dbus/machine-id "${builddir}"/etc/machine-id
+
+# Remove resolv.conf copied from the host by debootstrap. The settings
+# are only valid on the target host and will be populated at runtime.
+rm -f "${builddir}"/etc/resolv.conf
+
+# Remove temporary files
+rm -rf "${builddir}"/var/cache/man/*
+rm -rf "${builddir}"/tmp "${builddir}"/var/tmp
+mkdir -p "${builddir}"/tmp "${builddir}"/var/tmp
+chmod 1777 "${builddir}"/tmp "${builddir}"/var/tmp
+
+# OSTree uses a single checksum of the combined kernel and initramfs
+# to manage boot. Determine the checksum and rename the files the way
+# OSTree expects.
+echo "Renaming kernel and initramfs per OSTree requirements"
+pushd "${builddir}"/boot >/dev/null
+
+vmlinuz_match=(vmlinuz*)
+vmlinuz_file=${vmlinuz_match[0]}
+initrd_match=(initrd.img* initramfs*)
+initrd_file=${initrd_match[0]}
+
+csum=$(cat ${vmlinuz_file} ${initrd_file} | \
+	      sha256sum --binary | \
+	      awk '{print $1}')
+echo "OSTree boot checksum: ${csum}"
+
+mv ${vmlinuz_file} ${vmlinuz_file}-${csum}
+mv ${initrd_file} ${initrd_file/initrd.img/initramfs}-${csum}
+
+popd >/dev/null
+
+# OSTree only commits files or symlinks
+echo "Remove everything except files, directories and symlinks"
+rm -rf "${builddir}"/dev
+find "${builddir}" -type b,c,p,s -exec rm -v {} \;
+mkdir -p "${builddir}"/dev
+
+# Fixup home directory base paths for OSTree
+sed -i -e 's|DHOME=/home|DHOME=/sysroot/home|g' \
+    "${builddir}"/etc/adduser.conf
+sed -i -e 's|# HOME=/home|HOME=/sysroot/home|g' \
+    "${builddir}"/etc/default/useradd
+
+# Move /etc to /usr/etc.
+#
+# FIXME: Need to handle passwd and group to be updatable. This can be
+# done with libnss-altfiles, though that has other drawbacks.
+if [ -d "${builddir}"/usr/etc ]; then
+    echo "ERROR: Non-empty /usr/etc found!" >&2
+    ls -lR "${builddir}"/usr/etc
+    exit 1
+fi
+mv "${builddir}"/etc "${builddir}"/usr
+
+# Move dpkg database to /usr so it's accessible after the OS /var is
+# mounted, but make a symlink so it works without modifications to dpkg
+# or apt
+mkdir -p "${builddir}"/usr/share/dpkg
+if [ -e "${builddir}"/usr/share/dpkg/database ]; then
+    echo "ERROR: /usr/share/dpkg/database already exists!" >&2
+    ls -lR "${builddir}"/usr/share/dpkg/database >&2
+    exit 1
+fi
+mv "${builddir}"/var/lib/dpkg "${builddir}"/usr/share/dpkg/database
+ln -sr "${builddir}"/usr/share/dpkg/database \
+   "${builddir}"/var/lib/dpkg
+
+# tmpfiles.d setup to make the ostree root compatible with persistent
+# directories in the sysroot.
+cat > "${builddir}"/usr/lib/tmpfiles.d/ostree.conf <<EOF
+d /sysroot/home 0755 root root -
+d /sysroot/root 0700 root root -
+d /var/opt 0755 root root -
+d /var/local 0755 root root -
+d /run/media 0755 root root -
+L /var/lib/dpkg - - - - ../../usr/share/dpkg/database
+EOF
+
+# Create symlinks in the ostree for persistent directories.
+mkdir -p "${builddir}"/sysroot
+rm -rf "${builddir}"/{home,root,media,opt} "${builddir}"/usr/local
+ln -s /sysroot/ostree "${builddir}"/ostree
+ln -s /sysroot/home "${builddir}"/home
+ln -s /sysroot/root "${builddir}"/root
+ln -s /var/opt "${builddir}"/opt
+ln -s /var/local "${builddir}"/usr/local
+ln -s /run/media "${builddir}"/media
+
+
+
+
+
+
+# Based on https://github.com/dbnicholson/deb-ostree-builder/blob/15d8fe91af21592bf323fbf9aaf03b86bbe7359d/deb-ostree-builder
+# TODO(meisenzahl): support signing of repo
+# Now ready to commit. Make the repo if necessary. An archive-z2 repo
+# is used since the intention is to use this repo to serve updates
+# from.
+mkdir -p "${ostree_repo_dir}"
+if [ ! -f "${ostree_repo_dir}"/config ]; then
+    echo "Initialiazing OSTree repo ${ostree_repo_dir}"
+    ostree --repo="${ostree_repo_dir}" init --mode=archive-z2
+fi
+
+# Make the commit. The ostree ref is flatpak style.
+commit_opts=(
+    --repo="${ostree_repo_dir}"
+    --branch="${ostree_branch}"
+    --subject="Build elementary OS ${version} ${flatpak_architecture} $(date --iso-8601=seconds)"
+    --skip-if-unchanged
+    --table-output
+)
+# for id in ${GPG_SIGN[@]}; do
+#     commit_opts+=(--gpg-sign="$id")
+# done
+# if [ -n "$GPG_HOMEDIR" ]; then
+#     commit_opts+=(--gpg-homedir="$GPG_HOMEDIR")
+# fi
+echo "Committing ${builddir} to ${ostree_repo_dir} branch ${ostree_branch}"
+ostree commit "${commit_opts[@]}" "${builddir}"
+
+# Update the repo summary
+summary_opts=(
+    --repo="${ostree_repo_dir}"
+    --update
+)
+# for id in ${GPG_SIGN[@]}; do
+#     summary_opts+=(--gpg-sign="$id")
+# done
+# if [ -n "$GPG_HOMEDIR" ]; then
+#     summary_opts+=(--gpg-homedir="$GPG_HOMEDIR")
+# fi
+echo "Updating ${ostree_repo_dir} summary file"
+ostree summary "${summary_opts[@]}"


### PR DESCRIPTION
This PR is work in progress and aims to explore the possibilities for an OSTree-based image for elementary OS.

## Current state

An OSTree repository for OS 6 is created using the script `build-ostree-repository.sh`. This is based on our build scripts for the ARM based images and the `deb-ostree-builder` script from @dbnicholson in https://github.com/dbnicholson/deb-ostree-builder/tree/simple-builder.

The actual creation of an OSTree based image is done in `build-ostree-image.sh`. This script is heavily based on `create-deployment` from the mentioned repository. Here only paths and variables were adapted.

Unfortunately, the creation of an image just fails with the following error message:

```
error: Bootloader write config: /usr/sbin/grub-mkconfig: Child process exited with code 1
```

Although `grub-mkconfig` is installed:

```
# /usr/sbin/grub-mkconfig --version
grub-mkconfig (GRUB) 2.06-2
```

## TODOs

### OSTree repository

- [x] generate an OSTree repository
- [ ] configure mount points in `/etc/fstab` based on `ostree admin deploy`
- [ ] sign OSTree repository

### OSTree image

- [ ] generate a bootable image

## Contributing

Hints for trying out are in `README.md`. A short explanation of the implemented logic can be found in `CONTRIBUTING.md`.