### PR TITLE
Stable config: remove `-rc` suffix

### DIFF
--- a/etc/terraform-stable-azure.conf
+++ b/etc/terraform-stable-azure.conf
@@ -30,7 +30,7 @@ HWE_X11="no"
 INCLUDE_APPCENTER=""
 
 # suffix for generated .iso files
-OUTPUT_SUFFIX="-rc"
+OUTPUT_SUFFIX=""
 
 # folder suffix for the package lists to use
 PACKAGE_LISTS_SUFFIX="default"


### PR DESCRIPTION
Unless we want to keep this always, we can drop it again.