### PR TITLE
Workflows: Rename ARM workflow for clarity

### DIFF
--- a/.github/workflows/daily-6.1-arm.yml
+++ b/.github/workflows/daily-6.1-arm.yml
@@ -1,6 +1,6 @@
 ---
 
-name: Daily Build
+name: Daily Build (ARM)
 
 on:
   push:

--- a/build-pinebookpro.sh
+++ b/build-pinebookpro.sh
@@ -7,7 +7,7 @@ export architecture="arm64"
 export codename="focal"
 export channel="daily"
 
-version=6.0
+version=6.1
 YYYYMMDD="$(date +%Y%m%d)"
 imagename=elementaryos-$version-$channel-pinebookpro-$YYYYMMDD
 

--- a/build-rpi.sh
+++ b/build-rpi.sh
@@ -20,7 +20,7 @@ export architecture="arm64"
 export codename="focal"
 export channel="daily"
 
-version=6.0
+version=6.1
 YYYYMMDD="$(date +%Y%m%d)"
 imagename=elementaryos-$version-$channel-rpi-$YYYYMMDD
 


### PR DESCRIPTION
Also bumps the ARM versions to 6.1 for accuracy. We'll want to bump these to 7.0 once someone can test and validate them but in the meantime they should reflect the same version the OS itself says.