### PR TITLE
Use a safe(r) GRUB gfxmode

### DIFF
--- a/etc/config/bootloaders/grub-pc/grub.cfg
+++ b/etc/config/bootloaders/grub-pc/grub.cfg
@@ -1,6 +1,6 @@
 set default=0
 
-set gfxmode=auto
+set gfxmode=800x600
 loadfont $prefix/dejavu-bold-16.pf2
 loadfont $prefix/dejavu-bold-14.pf2
 loadfont $prefix/unicode.pf2


### PR DESCRIPTION
This fixes 2 known symptoms/issues with the installer:

1. The screen goes black after "Try or install" (see [https://github.com/elementary/os/issues/546](https://github.com/elementary/os/issues/546))
2. Installer fails with "error: out of memory" (see [https://github.com/elementary/installer/issues/542](https://github.com/elementary/installer/issues/542))

These issues might be specific to systems using HiDPI/4K monitors. My laptop happens to be one of those, and I've experienced the installer failing in both of these ways with `gfxmode=auto`.