### PR TITLE
Remove lupin-support from pool

### DIFF
--- a/etc/config/package-lists.default/pool.list.binary
+++ b/etc/config/package-lists.default/pool.list.binary
@@ -3,7 +3,6 @@ bcmwl-kernel-source
 dkms
 intel-microcode
 iucode-tool
-lupin-support
 setserial
 user-setup
 


### PR DESCRIPTION
This doesn't exist in `jammy` anymore and is causing the daily builds to fail as a result. There's not a lot of information about it online but it's something to do with being able to install with the iso mounted as a loop filesystem. Ubuntu have dropped it, and I highly doubt it's compatible with our installer anyway :shrug: