### PR TITLE
Issue Templates: point to contributor docs instead of github org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: settings://about
     about: If you're on elementary OS, report an issue from System Settings → About → Report a Problem
   - name: Report an issue with elementary OS on GitHub
-    url: https://github.com/elementary
-    about: Please find the appropriate repository and file an issue there
+    url: https://docs.elementary.io/contributor-guide/feedback/reporting-issues
+    about: See our contributor guide for help reporting issues


### PR DESCRIPTION
Fixes #616 