### PR TITLE
Add safe graphics option to boot menu

### DIFF
--- a/etc/config/bootloaders/grub-pc/grub.cfg
+++ b/etc/config/bootloaders/grub-pc/grub.cfg
@@ -23,6 +23,11 @@ menuentry "Try or install elementary OS" {
  initrd /casper/initrd.lz
 }
 
+menuentry "Try or install elementary OS (Safe graphics)" {
+ linux /casper/vmlinuz APPEND_LIVE nomodeset
+ initrd /casper/initrd.lz
+}
+
 submenu 'Advanced options...' {
 
 # More installer entries (if any)

--- a/etc/config/bootloaders/isolinux/live.cfg.in
+++ b/etc/config/bootloaders/isolinux/live.cfg.in
@@ -11,6 +11,12 @@ label live-@FLAVOUR@
 	initrd /casper/initrd.lz
 	append @APPEND_LIVE@
 
+label live-safe-@FLAVOUR@
+	menu label Try or install elementary OS (^Safe graphics)
+	linux /casper/vmlinuz
+	initrd /casper/initrd.lz
+	append @APPEND_LIVE@ nomodeset
+
 label check
 	menu label ^Check disk for defects
 	linux /casper/vmlinuz


### PR DESCRIPTION
Adds an option to the live CD boot menu to boot with `nomodeset` enabled, which should allow the ISO to boot on hardware we don't have working graphics drivers for.

Ubuntu upstream does something similar:
https://askubuntu.com/questions/1138137/what-is-safe-graphics-mode