### PR TITLE
Enable security repositories

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -46,6 +46,7 @@ lb config noauto \
     --firmware-binary false \
     --firmware-chroot false \
     --zsync false \
+    --security true \
     "${@}"
 
 # replace channel and suite


### PR DESCRIPTION
Related to #252 

According to https://manpages.ubuntu.com/manpages/bionic/man1/lb_config.1.html we have to explicitly enable security repositories.

> --security true|false
>            defines  if  the security repositories specified in the security mirror options should
>            be used or not.