### PR TITLE
Switch mode to debian

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -16,7 +16,7 @@ fi
 
 lb config noauto \
     --architectures "$ARCH" \
-    --mode ubuntu \
+    --mode debian \
     --initramfs none \
     --distribution "$BASECODENAME" \
     --parent-distribution "$BASECODENAME" \


### PR DESCRIPTION
Related to #252 

I had to dig through the code of `live-build` to find out that the versions of Debian and Ubuntu are implemented differently. By using `debian:latest` to build our images, the `mode` `ubuntu` is not supported. Only security repositories are enabled for `mode` `debian`: https://salsa.debian.org/live-team/live-build/-/blob/master/functions/sourcelist.sh#L77

## Before

```
deb mirror://mirrors.ubuntu.com/mirrors.txt jammy main restricted universe multiverse
deb-src mirror://mirrors.ubuntu.com/mirrors.txt jammy main restricted universe multiverse
deb mirror://mirrors.ubuntu.com/mirrors.txt jammy-updates main restricted universe multiverse
deb-src mirror://mirrors.ubuntu.com/mirrors.txt jammy-updates main restricted universe multiverse
```

## After

```
deb mirror://mirrors.ubuntu.com/mirrors.txt jammy main restricted universe multiverse
deb-src mirror://mirrors.ubuntu.com/mirrors.txt jammy main restricted universe multiverse
deb http://security.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse
deb-src http://security.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse
deb mirror://mirrors.ubuntu.com/mirrors.txt jammy-updates main restricted universe multiverse
deb-src mirror://mirrors.ubuntu.com/mirrors.txt jammy-updates main restricted universe multiverse
```