### PR TITLE
ARM: don't fail whole workflow if one config fails

### DIFF
--- a/.github/workflows/daily-6.1-arm.yml
+++ b/.github/workflows/daily-6.1-arm.yml
@@ -24,6 +24,8 @@ jobs:
 
           - name: Raspberry Pi
             script: ./build-rpi.sh
+      # Don't fail the whole workflow if one config fails
+      fail-fast: false
 
     steps:
       - name: Clean


### PR DESCRIPTION
It looks like currently Pinebook builds are failing which is causing Raspberry Pi builds to be canceled