### PR TITLE
Fix Pinebook Pro builds

### DIFF
--- a/.github/workflows/daily-6.1-arm.yml
+++ b/.github/workflows/daily-6.1-arm.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build (${{ matrix.configuration.name }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker run --privileged -i -v /proc:/proc \
 docker run --privileged -i -v /proc:/proc \
     -v ${PWD}:/working_dir \
     -w /working_dir \
-    debian:unstable \
+    ubuntu:20.04 \
     ./build-rpi.sh
 ```
 
@@ -58,7 +58,7 @@ docker run --privileged -i -v /proc:/proc \
 docker run --privileged -i -v /proc:/proc \
     -v ${PWD}:/working_dir \
     -w /working_dir \
-    debian:unstable \
+    ubuntu:20.04 \
     ./build-pinebookpro.sh
 ```
 


### PR DESCRIPTION
The issue with failing Pinebook Pro builds occured around 6 months ago. We use the WiFi and Bluetooth firmware from Manjaro. [6 months ago a file we rely on was renamed](https://gitlab.manjaro.org/manjaro-arm/packages/community/ap6256-firmware/-/commit/056d5f6776e515f90bbbbead1be06857aaef17d0). Because of this our Pinebook Pro builds started to fail:

```
...
Running in chroot, ignoring request.
 * Stopping SMP IRQ Balancer: irqbalance
   ...done.
Processing triggers for man-db (2.9.1-1) ...
Cloning into 'ap6256-firmware'...
cp: cannot stat 'nvram_ap6256.txt': No such file or directory
...
```

[Daily Build (ARM) · elementary/os@73d4076](https://github.com/elementary/os/actions/runs/3208455433/jobs/5244325444#step:4:12865)

@tintou fixed the issue in [pinebookpro: Update to latest ap6256-firmware git repository · elementary/os@288efe2](https://github.com/elementary/os/commit/288efe21ade712f561c21975f12315d677811ff0.)

We updated the CI image from ubuntu:20.04 to ubuntu:22.04 at the same time: [workflows: Update all the action dependencies · elementary/os@c1ef466](https://github.com/elementary/os/commit/c1ef466e1ccf131ded323d3b1fc422cd00ce36ce)

So a new issue arised: [Daily Build (ARM) · elementary/os@b16149f](https://github.com/elementary/os/actions/runs/3510448978/jobs/5880255183):

```
...
plat/rockchip/rk3399/drivers/dram/dram.c:13:22: error: ignoring attribute ‘section (".pmusram.data")’ because it conflicts with previous ‘section (".sram.data")’ [-Werror=attributes]
   13 | __pmusramdata struct rk3399_sdram_params sdram_config;
      |                      ^~~~~~~~~~~~~~~~~~~
In file included from plat/rockchip/rk3399/drivers/dram/dram.c:7:
plat/rockchip/rk3399/drivers/dram/dram.h:152:46: note: previous declaration here
  152 | extern __sramdata struct rk3399_sdram_params sdram_config;
      |                                              ^~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:1070: build/rk3399/release/bl31/dram.o] Error 1
...
```

Ubuntu 22.04 provides a newer version of the cross compiler which is not compatible with [TF-A/trusted-firmware-a
](https://review.trustedfirmware.org/q/project:TF-A%252Ftrusted-firmware-a). I tried to patch version 2.3 with a [provided patch](https://review.trustedfirmware.org/c/TF-A/trusted-firmware-a/+/10415). This solved the new issue but lead to a new error message that also occurs with all newer versions than 2.3.

<details>
<summary>Error messages of all minor updates from 2.3 to 2.7</summary>

```bash
### 2.3

plat/rockchip/rk3399/drivers/dram/dram.c:13:22: error: ignoring attribute ‘section (".pmusram.data")’ because it conflicts with previous ‘section (".sram.data")’ [-Werror=attributes]
   13 | __pmusramdata struct rk3399_sdram_params sdram_config;
      |                      ^~~~~~~~~~~~~~~~~~~
In file included from plat/rockchip/rk3399/drivers/dram/dram.c:7:
plat/rockchip/rk3399/drivers/dram/dram.h:152:46: note: previous declaration here
  152 | extern __sramdata struct rk3399_sdram_params sdram_config;
      |                                              ^~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:1070: build/rk3399/release/bl31/dram.o] Error 1



### 2.3 patched

make[1]: Leaving directory '/working_dir/pinebook-pro/trusted-firmware-a-2.3/plat/rockchip/rk3399/drivers/m0'
  CC      plat/rockchip/rk3399/drivers/pmu/pmu_fw.c
  CC      plat/rockchip/rk3399/drivers/pwm/pwm.c
  CC      plat/rockchip/rk3399/drivers/secure/secure.c
  CC      plat/rockchip/rk3399/drivers/soc/soc.c
  CC      plat/rockchip/rk3399/plat_sip_calls.c
  CC      services/arm_arch_svc/arm_arch_svc_setup.c
  CC      services/std_svc/std_svc_setup.c
  CC      common/bl_common.c
  CC      common/tf_log.c
  CC      drivers/console/multi_console.c
  CC      plat/common/plat_bl_common.c
  CC      plat/common/plat_log_common.c
  CC      plat/common/aarch64/plat_common.c
  CC      lib/compiler-rt/builtins/popcountdi2.c
  CC      lib/compiler-rt/builtins/popcountsi2.c
  CC      common/desc_image_load.c
  CC      lib/bl_aux_params/bl_aux_params.c
  CC      lib/xlat_tables/xlat_tables_common.c
  CC      lib/xlat_tables/aarch64/xlat_tables.c
  CC      plat/common/plat_psci_common.c
  AS      bl31/aarch64/bl31_entrypoint.S
  AS      bl31/aarch64/crash_reporting.S
  AS      bl31/aarch64/ea_delegate.S
  AS      bl31/aarch64/runtime_exceptions.S
  AS      drivers/ti/uart/aarch64/16550_console.S
  AS      lib/cpus/aarch64/cortex_a53.S
  AS      lib/cpus/aarch64/cortex_a72.S
  AS      lib/cpus/aarch64/cpu_helpers.S
  AS      lib/cpus/aarch64/dsu_helpers.S
  AS      lib/cpus/aarch64/wa_cve_2017_5715_bpiall.S
  AS      lib/cpus/aarch64/wa_cve_2017_5715_mmu.S
  AS      lib/el3_runtime/aarch64/context.S
  AS      lib/el3_runtime/aarch64/cpu_data.S
  AS      lib/locks/exclusive/aarch64/spinlock.S
  AS      lib/psci/aarch64/psci_helpers.S
  AS      plat/common/aarch64/platform_mp_stack.S
  AS      plat/rockchip/common/aarch64/plat_helpers.S
  AS      plat/rockchip/common/aarch64/pmu_sram_cpus_on.S
  AS      common/aarch64/debug.S
  AS      lib/aarch64/cache_helpers.S
  AS      lib/aarch64/misc_helpers.S
  AS      plat/common/aarch64/platform_helpers.S
  AS      plat/common/aarch64/crash_console_helpers.S
  PP      bl31/bl31.ld.S
  LD      build/rk3399/release/bl31/bl31.elf
aarch64-linux-gnu-ld.bfd: warning: build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions
aarch64-linux-gnu-ld.bfd: warning: build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions
aarch64-linux-gnu-ld.bfd: warning: build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions
make: *** [Makefile:1071: build/rk3399/release/bl31/bl31.elf] Error 1


### 2.4

plat/rockchip/rk3399/drivers/dram/dram.c:13:22: error: ignoring attribute 'section (".pmusram.data")' because it conflicts with previous 'section (".sram.data")' [-Werror=attributes]
   13 | __pmusramdata struct rk3399_sdram_params sdram_config;
      |                      ^~~~~~~~~~~~~~~~~~~
In file included from plat/rockchip/rk3399/drivers/dram/dram.c:7:
plat/rockchip/rk3399/drivers/dram/dram.h:152:46: note: previous declaration here
  152 | extern __sramdata struct rk3399_sdram_params sdram_config;
      |                                              ^~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:1104: /working_dir/pinebook-pro/trusted-firmware-a-2.4/build/rk3399/release/bl31/dram.o] Error 1


### 2.5

plat/rockchip/rk3399/drivers/dram/dram.c:13:22: error: ignoring attribute 'section (".pmusram.data")' because it conflicts with previous 'section (".sram.data")' [-Werror=attributes]
   13 | __pmusramdata struct rk3399_sdram_params sdram_config;
      |                      ^~~~~~~~~~~~~~~~~~~
In file included from plat/rockchip/rk3399/drivers/dram/dram.c:7:
plat/rockchip/rk3399/drivers/dram/dram.h:152:46: note: previous declaration here
  152 | extern __sramdata struct rk3399_sdram_params sdram_config;
      |                                              ^~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:1142: /working_dir/pinebook-pro/trusted-firmware-a-2.5/build/rk3399/release/bl31/dram.o] Error 1


### 2.6

make[1]: Leaving directory '/working_dir/pinebook-pro/trusted-firmware-a-2.6/plat/rockchip/rk3399/drivers/m0'
  CC      plat/rockchip/rk3399/drivers/pmu/pmu_fw.c
  CC      plat/rockchip/rk3399/drivers/pwm/pwm.c
  CC      plat/rockchip/rk3399/drivers/secure/secure.c
  CC      plat/rockchip/rk3399/drivers/soc/soc.c
  CC      plat/rockchip/rk3399/plat_sip_calls.c
  CC      services/arm_arch_svc/arm_arch_svc_setup.c
  CC      services/std_svc/std_svc_setup.c
  CC      common/bl_common.c
  CC      common/tf_log.c
  CC      drivers/console/multi_console.c
  CC      plat/common/plat_bl_common.c
  CC      plat/common/plat_log_common.c
  CC      plat/common/aarch64/plat_common.c
  CC      lib/compiler-rt/builtins/popcountdi2.c
  CC      lib/compiler-rt/builtins/popcountsi2.c
  CC      common/desc_image_load.c
  CC      lib/bl_aux_params/bl_aux_params.c
  CC      lib/xlat_tables/xlat_tables_common.c
  CC      lib/xlat_tables/aarch64/xlat_tables.c
  CC      plat/common/plat_psci_common.c
  AS      bl31/aarch64/bl31_entrypoint.S
  AS      bl31/aarch64/crash_reporting.S
  AS      bl31/aarch64/ea_delegate.S
  AS      bl31/aarch64/runtime_exceptions.S
  AS      drivers/ti/uart/aarch64/16550_console.S
  AS      lib/cpus/aarch64/cortex_a53.S
  AS      lib/cpus/aarch64/cortex_a72.S
  AS      lib/cpus/aarch64/cpu_helpers.S
  AS      lib/cpus/aarch64/dsu_helpers.S
  AS      lib/cpus/aarch64/wa_cve_2017_5715_bpiall.S
  AS      lib/cpus/aarch64/wa_cve_2017_5715_mmu.S
  AS      lib/el3_runtime/aarch64/context.S
  AS      lib/el3_runtime/aarch64/cpu_data.S
  AS      lib/locks/exclusive/aarch64/spinlock.S
  AS      lib/psci/aarch64/psci_helpers.S
  AS      plat/common/aarch64/platform_mp_stack.S
  AS      plat/rockchip/common/aarch64/plat_helpers.S
  AS      plat/rockchip/common/aarch64/pmu_sram_cpus_on.S
  AS      common/aarch64/debug.S
  AS      lib/aarch64/cache_helpers.S
  AS      lib/aarch64/misc_helpers.S
  AS      plat/common/aarch64/platform_helpers.S
  AS      plat/common/aarch64/crash_console_helpers.S
  PP      bl31/bl31.ld.S
  LD      /working_dir/pinebook-pro/trusted-firmware-a-2.6/build/rk3399/release/bl31/bl31.elf
aarch64-linux-gnu-ld.bfd: warning: /working_dir/pinebook-pro/trusted-firmware-a-2.6/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions
aarch64-linux-gnu-ld.bfd: warning: /working_dir/pinebook-pro/trusted-firmware-a-2.6/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions
aarch64-linux-gnu-ld.bfd: warning: /working_dir/pinebook-pro/trusted-firmware-a-2.6/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions
make: *** [Makefile:1252: /working_dir/pinebook-pro/trusted-firmware-a-2.6/build/rk3399/release/bl31/bl31.elf] Error 1


make[1]: Leaving directory '/working_dir/pinebook-pro/trusted-firmware-a-2.7.0/plat/rockchip/rk3399/drivers/m0'
  CC      plat/rockchip/rk3399/drivers/pmu/pmu_fw.c
  CC      plat/rockchip/rk3399/drivers/pwm/pwm.c
  CC      plat/rockchip/rk3399/drivers/secure/secure.c
  CC      plat/rockchip/rk3399/drivers/soc/soc.c
  CC      plat/rockchip/rk3399/plat_sip_calls.c
  CC      services/arm_arch_svc/arm_arch_svc_setup.c
  CC      services/std_svc/std_svc_setup.c
  CC      common/bl_common.c
  CC      common/tf_log.c
  CC      drivers/console/multi_console.c
  CC      plat/common/plat_bl_common.c
  CC      plat/common/plat_log_common.c
  CC      plat/common/aarch64/plat_common.c
  CC      lib/compiler-rt/builtins/popcountdi2.c
  CC      lib/compiler-rt/builtins/popcountsi2.c
  CC      common/desc_image_load.c
  CC      lib/bl_aux_params/bl_aux_params.c
  CC      lib/xlat_tables/xlat_tables_common.c
  CC      lib/xlat_tables/aarch64/xlat_tables.c
  CC      plat/common/plat_psci_common.c
  AS      bl31/aarch64/bl31_entrypoint.S
  AS      bl31/aarch64/crash_reporting.S
  AS      bl31/aarch64/ea_delegate.S
  AS      bl31/aarch64/runtime_exceptions.S
  AS      drivers/ti/uart/aarch64/16550_console.S
  AS      lib/cpus/aarch64/cortex_a53.S
  AS      lib/cpus/aarch64/cortex_a72.S
  AS      lib/cpus/aarch64/cpu_helpers.S
  AS      lib/cpus/aarch64/dsu_helpers.S
  AS      lib/cpus/aarch64/wa_cve_2017_5715_bpiall.S
  AS      lib/cpus/aarch64/wa_cve_2017_5715_mmu.S
  AS      lib/el3_runtime/aarch64/context.S
  AS      lib/el3_runtime/aarch64/cpu_data.S
  AS      lib/locks/exclusive/aarch64/spinlock.S
  AS      lib/psci/aarch64/psci_helpers.S
  AS      plat/common/aarch64/platform_mp_stack.S
  AS      plat/rockchip/common/aarch64/plat_helpers.S
  AS      plat/rockchip/common/aarch64/pmu_sram_cpus_on.S
  AS      common/aarch64/debug.S
  AS      lib/aarch64/cache_helpers.S
  AS      lib/aarch64/misc_helpers.S
  AS      plat/common/aarch64/platform_helpers.S
  AS      plat/common/aarch64/crash_console_helpers.S
  PP      bl31/bl31.ld.S
  LD      /working_dir/pinebook-pro/trusted-firmware-a-2.7.0/build/rk3399/release/bl31/bl31.elf
aarch64-linux-gnu-ld.bfd: warning: /working_dir/pinebook-pro/trusted-firmware-a-2.7.0/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions
aarch64-linux-gnu-ld.bfd: warning: /working_dir/pinebook-pro/trusted-firmware-a-2.7.0/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions
aarch64-linux-gnu-ld.bfd: warning: /working_dir/pinebook-pro/trusted-firmware-a-2.7.0/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions
make: *** [Makefile:1306: /working_dir/pinebook-pro/trusted-firmware-a-2.7.0/build/rk3399/release/bl31/bl31.elf] Error 1




### 2.7

make[1]: Leaving directory '/working_dir/pinebook-pro/trusted-firmware-a-2.7/plat/rockchip/rk3399/drivers/m0'
  CC      plat/rockchip/rk3399/drivers/pmu/pmu_fw.c
  CC      plat/rockchip/rk3399/drivers/pwm/pwm.c
  CC      plat/rockchip/rk3399/drivers/secure/secure.c
  CC      plat/rockchip/rk3399/drivers/soc/soc.c
  CC      plat/rockchip/rk3399/plat_sip_calls.c
  CC      services/arm_arch_svc/arm_arch_svc_setup.c
  CC      services/std_svc/std_svc_setup.c
  CC      common/bl_common.c
  CC      common/tf_log.c
  CC      drivers/console/multi_console.c
  CC      plat/common/plat_bl_common.c
  CC      plat/common/plat_log_common.c
  CC      plat/common/aarch64/plat_common.c
  CC      lib/compiler-rt/builtins/popcountdi2.c
  CC      lib/compiler-rt/builtins/popcountsi2.c
  CC      common/desc_image_load.c
  CC      lib/bl_aux_params/bl_aux_params.c
  CC      lib/xlat_tables/xlat_tables_common.c
  CC      lib/xlat_tables/aarch64/xlat_tables.c
  CC      plat/common/plat_psci_common.c
  AS      bl31/aarch64/bl31_entrypoint.S
  AS      bl31/aarch64/crash_reporting.S
  AS      bl31/aarch64/ea_delegate.S
  AS      bl31/aarch64/runtime_exceptions.S
  AS      drivers/ti/uart/aarch64/16550_console.S
  AS      lib/cpus/aarch64/cortex_a53.S
  AS      lib/cpus/aarch64/cortex_a72.S
  AS      lib/cpus/aarch64/cpu_helpers.S
  AS      lib/cpus/aarch64/dsu_helpers.S
  AS      lib/cpus/aarch64/wa_cve_2017_5715_bpiall.S
  AS      lib/cpus/aarch64/wa_cve_2017_5715_mmu.S
  AS      lib/el3_runtime/aarch64/context.S
  AS      lib/el3_runtime/aarch64/cpu_data.S
  AS      lib/locks/exclusive/aarch64/spinlock.S
  AS      lib/psci/aarch64/psci_helpers.S
  AS      plat/common/aarch64/platform_mp_stack.S
  AS      plat/rockchip/common/aarch64/plat_helpers.S
  AS      plat/rockchip/common/aarch64/pmu_sram_cpus_on.S
  AS      common/aarch64/debug.S
  AS      lib/aarch64/cache_helpers.S
  AS      lib/aarch64/misc_helpers.S
  AS      plat/common/aarch64/platform_helpers.S
  AS      plat/common/aarch64/crash_console_helpers.S
  PP      bl31/bl31.ld.S
  LD      /working_dir/pinebook-pro/trusted-firmware-a-2.7/build/rk3399/release/bl31/bl31.elf
aarch64-linux-gnu-ld.bfd: warning: /working_dir/pinebook-pro/trusted-firmware-a-2.7/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions
aarch64-linux-gnu-ld.bfd: warning: /working_dir/pinebook-pro/trusted-firmware-a-2.7/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions
aarch64-linux-gnu-ld.bfd: warning: /working_dir/pinebook-pro/trusted-firmware-a-2.7/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions
make: *** [Makefile:1306: /working_dir/pinebook-pro/trusted-firmware-a-2.7/build/rk3399/release/bl31/bl31.elf] Error 1
```

</details>

Therefore, I suggest that we use Ubuntu 20.04 for the time being to be able to offer builds for the Pinebook Pro again.

A release candidate for version 2.8 of the firmware is currently being worked on. Maybe it will fix the problem.

Alternatively, we would have to provide an older version of the Cross Compile Toolchain for Ubuntu 22.04. This seems to be a bit much effort...
