### PR TITLE
archives: Use https link for the PPAs

### DIFF
--- a/etc/config/archives/elementary.list
+++ b/etc/config/archives/elementary.list
@@ -1,3 +1,3 @@
-deb http://ppa.launchpad.net/elementary-os/@CHANNEL/ubuntu @BASECODENAME main 
-deb-src http://ppa.launchpad.net/elementary-os/@CHANNEL/ubuntu @BASECODENAME main 
+deb https://ppa.launchpadcontent.net/elementary-os/@CHANNEL/ubuntu @BASECODENAME main 
+deb-src https://ppa.launchpadcontent.net/elementary-os/@CHANNEL/ubuntu @BASECODENAME main 
 

--- a/etc/config/archives/patches.list
+++ b/etc/config/archives/patches.list
@@ -1,3 +1,3 @@
-deb http://ppa.launchpad.net/elementary-os/os-patches/ubuntu @BASECODENAME main 
-deb-src http://ppa.launchpad.net/elementary-os/os-patches/ubuntu @BASECODENAME main 
+deb https://ppa.launchpadcontent.net/elementary-os/os-patches/ubuntu @BASECODENAME main 
+deb-src https://ppa.launchpadcontent.net/elementary-os/os-patches/ubuntu @BASECODENAME main 
 


### PR DESCRIPTION
The PPAs are available via HTTPS since february as per https://blog.launchpad.net/ppa/new-domain-names-for-ppas