### PR TITLE
RPi Build Script: Fix loopback device setup on system with >10 devices

### DIFF
--- a/build-rpi.sh
+++ b/build-rpi.sh
@@ -172,7 +172,7 @@ parted "${imagename}.img" --script -- mkpart primary ext4 256 -1
 
 # Set the partition variables
 loopdevice=$(losetup -f --show "${basedir}/${imagename}.img")
-device=$(kpartx -va "$loopdevice" | sed -E 's/.*(loop[0-9])p.*/\1/g' | head -1)
+device=$(kpartx -va "$loopdevice" | sed -E 's/.*(loop[0-9]+)p.*/\1/g' | head -1)
 device="/dev/mapper/${device}"
 bootp=${device}p1
 rootp=${device}p2


### PR DESCRIPTION
This is a minor fix for the Raspberry Pi build script, where the loop device name was overly-constrained in a regular expression.

```
loop9p1 - matched
loop10p1 - not a match
```

I changed the regular expression slightly so that more than one digit in the loop device name would be accepted.

```diff
- .*(loop[0-9])p.*
+ .*(loop[0-9]+)p.*
```

```
loop9p1 - matched
loop10p1 - matched
```

On host systems with more than 10 loop devices already present, the existing regular expression wouldn't match the newly-created loop device. The failed match resulted in the entire `kpartx` command output ending-up in the `device` variable, causing mkfs commands to fail. Here's an example mkfs command in a failed build:

```
mkfs.vfat -n system-boot '/dev/mapper/add map loop31p1 (253:0): 0 500000 linear 7:31 1p1'
```

Results in the error message:

> mkfs.vfat: unable to open /dev/mapper/add map loop31p1 (253:0): 0 500000 linear 7:31 1p1: No such file or directory


Why would someone have so many loop devices? With Snap packages installed under Ubuntu, it seems to be mounting them from images on a loopback device, similar to the way Docker mounts filesystems for images.