### PR TITLE
Update RPi build script to Horus

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker run --privileged -i -v /proc:/proc \
 docker run --privileged -i -v /proc:/proc \
     -v ${PWD}:/working_dir \
     -w /working_dir \
-    ubuntu:20.04 \
+    ubuntu:22.04 \
     ./build-rpi.sh
 ```
 

--- a/build-rpi.sh
+++ b/build-rpi.sh
@@ -17,10 +17,10 @@ free_space="500"
 
 export packages="elementary-minimal elementary-desktop elementary-standard"
 export architecture="arm64"
-export codename="focal"
+export codename="jammy"
 export channel="daily"
 
-version=6.1
+version=7.0
 YYYYMMDD="$(date +%Y%m%d)"
 imagename=elementaryos-$version-$channel-rpi-$YYYYMMDD
 
@@ -210,7 +210,7 @@ chmod +x elementary-$architecture/hardware
 LANG=C chroot elementary-$architecture /hardware
 
 # Grab some updated firmware from the Raspberry Pi foundation
-git clone -b '1.20201022' --single-branch --depth 1 https://github.com/raspberrypi/firmware raspi-firmware
+git clone -b 'stable' --single-branch --depth 1 https://github.com/raspberrypi/firmware raspi-firmware
 cp raspi-firmware/boot/*.elf "${basedir}/bootp/"
 cp raspi-firmware/boot/*.dat "${basedir}/bootp/"
 cp raspi-firmware/boot/bootcode.bin "${basedir}/bootp/"


### PR DESCRIPTION
I was pleasantly surprised at how straightforward it was to make these changes and build the image locally--your documentation is superb.

The build script (I used a 22.04 base image) had no trouble producing the image, and the image itself set up and installed just fine on my Raspberry Pi.

In fact, I'm opening this PR _from_ the Pi itself.

![Proof of Life](https://github.com/elementary/os/assets/66568922/c3ee0867-dacf-4199-bac6-38aaf8287352)

I'm not going to lie and claim that it isn't _painfully_ slow to use, but my wifi and peripherals are all recognized out of the box, and I'm running a 1440p display, so I'm not complaining.