### PR TITLE
Stop using mirror lists

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -33,8 +33,8 @@ lb config noauto \
     --parent-mirror-chroot-security "http://security.ubuntu.com/ubuntu/" \
     --mirror-binary-security "http://security.ubuntu.com/ubuntu/" \
     --parent-mirror-binary-security "http://security.ubuntu.com/ubuntu/" \
-    --mirror-binary "mirror://mirrors.ubuntu.com/mirrors.txt" \
-    --parent-mirror-binary "mirror://mirrors.ubuntu.com/mirrors.txt" \
+    --mirror-binary "http://archive.ubuntu.com/ubuntu/" \
+    --parent-mirror-binary "http://archive.ubuntu.com/ubuntu/" \
     --keyring-packages ubuntu-keyring \
     --apt-options "--yes --option Acquire::Retries=2 --option Acquire::http::Timeout=45" \
     --cache-packages false \


### PR DESCRIPTION
Partially reverts #328 

I'm seeing regular issues with these mirror lists on my installed system where `apt` will get stuck on some garbage tier mirror while trying to do updates.

Ever since #328 has been merged, we've been seeing the daily builds of the iso fail due to the same issue on occasion, and it feels like the frequency of this is increasing.

It also seems I'm not alone in this issue: 
- #636 
- https://github.com/orgs/elementary/discussions/271

I think we did this originally due to something about maybe ending up with a country specific mirror (i.e. `us.archive.ubuntu.com`) after installation, or maybe the fact that the default mirror without a country prefix only has servers in the UK and US and is therefore maybe less efficient for users elsewhere in the world.

Either way, I think we should give this another try, and maybe look at having initial setup set the right mirror for the country after installation if we still think there are issues.