### PR TITLE
Add open-vm-tools to pool

### DIFF
--- a/etc/config/package-lists/pool.list.binary
+++ b/etc/config/package-lists/pool.list.binary
@@ -3,6 +3,7 @@ bcmwl-kernel-source
 dkms
 intel-microcode
 iucode-tool
+open-vm-tools-desktop
 setserial
 user-setup
 


### PR DESCRIPTION
This allows the "additional drivers" step of the installer to install these drivers for VMware support without an internet connection.

Should improve our VM support somewhat.

Related to https://github.com/elementary/installer/issues/723