### PR TITLE
Install kernel headers by default

### DIFF
--- a/etc/auto/config
+++ b/etc/auto/config
@@ -61,3 +61,4 @@ sed -i "s/@VERSION/$VERSION/" config/includes.binary/.disk/info
 sed -i "s/@DATE/$DATE/" config/includes.binary/.disk/info
 
 sed -i "s/@XORG_HWE/$XORG_HWE/" config/package-lists/desktop.list.chroot_install
+sed -i "s/@KERNEL_HEADERS/linux-headers-$KERNEL_FLAVORS/" config/package-lists/desktop.list.chroot_install

--- a/etc/config/package-lists/desktop.list.chroot_install
+++ b/etc/config/package-lists/desktop.list.chroot_install
@@ -4,3 +4,4 @@ elementary-minimal
 elementary-standard
 
 @XORG_HWE
+@KERNEL_HEADERS


### PR DESCRIPTION
There are multiple cases where installing a piece of software or a driver results in that software or driver not working afterwards due to the user not realising it needs kernel headers installed too:

VirtualBox - https://github.com/orgs/elementary/discussions/291
Nvidia drivers - https://github.com/elementary/os-patches/issues/155
Broadcom drivers - https://github.com/elementary/appcenter/issues/1603

These packages generally don't depend on kernel headers, since putting a dependency in the packaging when you don't know what kernel version/flavour it will be running against doesn't make sense.

So we can make the user experience quite a bit better here by having elementary OS come pre-installed with the correct kernel headers for the kernel flavour we ship. The package doesn't do anything on its own, so there's no risk here. It will just take a few extra tens of megabytes of disk space on an installed system.