### PR TITLE
build: Add a debootstrap symlink for mantic

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,10 @@ apt-key adv --recv-keys --keyserver keyserver.ubuntu.com F6ECB3762474EDA9D21B702
 # This can be removed when our Debian container has a version containing this fix
 patch -d /usr/lib/live/build/ < 314-follow-symlinks-when-measuring-size-of-efi-files.patch
 
+# TODO: Remove this once debootstrap has a script to build mantic images in our container:
+# https://salsa.debian.org/installer-team/debootstrap/blob/master/debian/changelog
+ln -sfn /usr/share/debootstrap/scripts/gutsy /usr/share/debootstrap/scripts/mantic
+
 build () {
   BUILD_ARCH="$1"
 


### PR DESCRIPTION
Allows debootstrap to work with `mantic`