### PR TITLE
Raspberry Pi: Disable merged-usr of debootstrap

### DIFF
--- a/build-rpi.sh
+++ b/build-rpi.sh
@@ -28,7 +28,10 @@ mkdir -p "${basedir}"
 cd "${basedir}"
 
 # Bootstrap an ubuntu minimal system
-debootstrap --foreign --arch $architecture $codename elementary-$architecture http://ports.ubuntu.com/ubuntu-ports
+# Disable merged-usr because base-files on noble or later contains symlink to /bin, /lib, /lib64, and /sbin,
+# which causes extracting base-files failing.
+# See https://bugs.launchpad.net/ubuntu/+source/base-files/+bug/2054925
+debootstrap --foreign --no-merged-usr --arch $architecture $codename elementary-$architecture http://ports.ubuntu.com/ubuntu-ports
 
 # Add the QEMU emulator for running ARM executables
 cp /usr/bin/qemu-arm-static elementary-$architecture/usr/bin/


### PR DESCRIPTION
Fixes #727

base-files on noble or later contains symlink to /bin, /lib, /lib64, and /sbin as you can see at https://packages.ubuntu.com/en/noble/arm64/base-files/filelist

However, because debootstrap already setup these symlinks, extracting base-files fails with the following error:

    I: Extracting base-files...
    E: Tried to extract package, but file already exists. Exit...

(See also https://bugs.launchpad.net/ubuntu/+source/base-files/+bug/2054925)

This commit prevent debootstrap from setting up symlinks and let base-files do that job instead.