### PR TITLE
arm64: Build on Noble

### DIFF
--- a/.github/workflows/daily-arm.yml
+++ b/.github/workflows/daily-arm.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build (${{ matrix.configuration.name }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-.venv
 tmp
 artifacts
 builds

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.venv
 tmp
 artifacts
 builds

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker run --rm --privileged -it \
     -v /proc:/proc \
     -v ${PWD}:/working_dir \
     -w /working_dir \
-    ubuntu:22.04 \
+    ubuntu:24.04 \
     ./build-rpi.sh
 ```
 
@@ -61,7 +61,7 @@ docker run --rm --privileged -it \
     -v /proc:/proc \
     -v ${PWD}:/working_dir \
     -w /working_dir \
-    ubuntu:20.04 \
+    ubuntu:24.04 \
     ./build-pinebookpro.sh
 ```
 

--- a/build-pinebookpro.sh
+++ b/build-pinebookpro.sh
@@ -354,11 +354,13 @@ BUCKET="$4"
 IMGPATH="${basedir}"/${imagename}.img.xz
 IMGNAME=${channel}-pinebookpro/$(basename "$IMGPATH")
 
-apt-get install -y curl python3 python3-distutils
+apt-get install -y python3 python3-pip python3-venv
 
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-python3 get-pip.py
-pip install boto3
+python3 -m venv .venv
+. .venv/bin/activate
+trap 'deactivate' EXIT
+
+pip3 install boto3
 
 python3 upload.py "$KEY" "$SECRET" "$ENDPOINT" "$BUCKET" "$IMGPATH" "$IMGNAME" || exit 1
 

--- a/build-pinebookpro.sh
+++ b/build-pinebookpro.sh
@@ -354,13 +354,7 @@ BUCKET="$4"
 IMGPATH="${basedir}"/${imagename}.img.xz
 IMGNAME=${channel}-pinebookpro/$(basename "$IMGPATH")
 
-apt-get install -y python3 python3-pip python3-venv
-
-python3 -m venv .venv
-. .venv/bin/activate
-trap 'deactivate' EXIT
-
-pip3 install boto3
+apt-get install -y python3 python3-boto3
 
 python3 upload.py "$KEY" "$SECRET" "$ENDPOINT" "$BUCKET" "$IMGPATH" "$IMGNAME" || exit 1
 

--- a/build-rpi.sh
+++ b/build-rpi.sh
@@ -234,11 +234,13 @@ BUCKET="$4"
 IMGPATH="${basedir}"/${imagename}.img.xz
 IMGNAME=${channel}-rpi/$(basename "$IMGPATH")
 
-apt-get install -y curl python3 python3-distutils
+apt-get install -y python3 python3-pip python3-venv
 
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-python3 get-pip.py
-pip install boto3
+python3 -m venv .venv
+. .venv/bin/activate
+trap 'deactivate' EXIT
+
+pip3 install boto3
 
 python3 upload.py "$KEY" "$SECRET" "$ENDPOINT" "$BUCKET" "$IMGPATH" "$IMGNAME" || exit 1
 

--- a/build-rpi.sh
+++ b/build-rpi.sh
@@ -234,13 +234,7 @@ BUCKET="$4"
 IMGPATH="${basedir}"/${imagename}.img.xz
 IMGNAME=${channel}-rpi/$(basename "$IMGPATH")
 
-apt-get install -y python3 python3-pip python3-venv
-
-python3 -m venv .venv
-. .venv/bin/activate
-trap 'deactivate' EXIT
-
-pip3 install boto3
+apt-get install -y python3 python3-boto3
 
 python3 upload.py "$KEY" "$SECRET" "$ENDPOINT" "$BUCKET" "$IMGPATH" "$IMGNAME" || exit 1
 


### PR DESCRIPTION
Fix #727
Closes #728

The fix for https://bugs.launchpad.net/ubuntu/+source/base-files/+bug/2054925 does not seem to be released for Ubuntu 20.04 LTS. This issue didn't occur when I tested on OS 8 RC, so switch build environment to Ubuntu 24.04 LTS.

## Changes Summary
- Update build environment to Ubuntu 24.04 LTS
- Do not install `python3-distutils` that is no longer provided since Ubuntu 24.04 LTS
- Install pip3 and boto3 from apt
