### PR TITLE
Create apparmor-profiles.chroot

### DIFF
--- a/etc/config/hooks/live/apparmor-profiles.chroot
+++ b/etc/config/hooks/live/apparmor-profiles.chroot
@@ -1,4 +1,4 @@
 #!/bin/sh
-# Description: install experiment profiles for bubble wrap so Flatpak apps can open in Demo Mode
+# Description: enable experimental AppArmor profile for bubblewrap so Flatpak apps can open in Demo Mode
 
-apparmor_parser -r /usr/share/apparmor/extra-profiles/bwrap-userns-restrict
+ln -s /usr/share/apparmor/extra-profiles/bwrap-userns-restrict /etc/apparmor.d/

--- a/etc/config/hooks/live/apparmor-profiles.chroot
+++ b/etc/config/hooks/live/apparmor-profiles.chroot
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Description: install experiment profiles for bubble wrap so Flatpak apps can open in Demo Mode
+
+apparmor_parser -r /usr/share/apparmor/extra-profiles/bwrap-userns-restrict


### PR DESCRIPTION
Fixes https://github.com/elementary/triage/issues/600

Errors with:

```
Cache read/write disabled: interface file missing. (Kernel needs AppArmor 2.4 compatibility patch.)
Warning: unable to find a suitable fs in /proc/mounts, is it mounted?
Use --subdomainfs to override.
```