### PR TITLE
README: Update stable badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </div>
 
 <p align="center">
-  <img src="https://github.com/elementary/os/workflows/stable/badge.svg" alt="Stable">
+  <img src="https://github.com/elementary/os/actions/workflows/stable-8.0.yml/badge.svg" alt="Stable 8.0">
   <img src="https://github.com/elementary/os/actions/workflows/daily-8.0.yml/badge.svg" alt="Daily 8.0">
   <img src="https://github.com/elementary/os/actions/workflows/daily-arm.yml/badge.svg" alt="Daily ARM">
 


### PR DESCRIPTION
The previous badge points to the old workflow removed in #725.