### PR TITLE
ARM: native build support

### DIFF
--- a/.github/workflows/daily-8.0-arm64.yml
+++ b/.github/workflows/daily-8.0-arm64.yml
@@ -1,0 +1,27 @@
+name: Daily OS 8 ARM64
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+
+    container:
+      image: debian:sid
+      volumes:
+        - /proc:/proc
+      options: --privileged
+
+    steps:
+    - name: Clone build scripts
+      uses: actions/checkout@v4
+
+    - name: Build and upload daily .iso
+      run: |
+        ./workflows-arm64.sh etc/terraform-daily-8.0-azure-arm64.conf "${{ secrets.key }}" "${{ secrets.secret }}" "${{ secrets.endpoint }}" "${{ secrets.bucket }}"

--- a/build-arm64.sh
+++ b/build-arm64.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -e
+
+# check for root permissions
+if [[ "$(id -u)" != 0 ]]; then
+  echo "E: Requires root permissions" > /dev/stderr
+  exit 1
+fi
+
+# get config
+if [ -n "$1" ]; then
+  CONFIG_FILE="$1"
+else
+  CONFIG_FILE="etc/terraform.conf"
+fi
+BASE_DIR="$PWD"
+source "$BASE_DIR"/"$CONFIG_FILE"
+
+echo -e "
+#----------------------#
+# INSTALL DEPENDENCIES #
+#----------------------#
+"
+
+apt-get update
+apt-get install -y live-build patch gnupg2 binutils zstd
+
+# The Debian repositories don't seem to have the `ubuntu-keyring` or `ubuntu-archive-keyring` packages
+# anymore, so we add the archive keys manually. This may need to be updated if Ubuntu changes their signing keys
+# To get the current key ID, find `ubuntu-keyring-xxxx-archive.gpg` in /etc/apt/trusted.gpg.d on a running
+# system and run `gpg --keyring /etc/apt/trusted.gpg.d/ubuntu-keyring-xxxx-archive.gpg --list-public-keys `
+gpg --homedir /tmp --no-default-keyring --keyring /etc/apt/trusted.gpg --recv-keys --keyserver keyserver.ubuntu.com F6ECB3762474EDA9D21B7022871920D1991BC93C
+
+# TODO: Remove this once debootstrap can natively build noble images:
+ln -sfn /usr/share/debootstrap/scripts/gutsy /usr/share/debootstrap/scripts/noble
+
+build () {
+  BUILD_ARCH="$1"
+
+  mkdir -p "$BASE_DIR/tmp/$BUILD_ARCH"
+  cd "$BASE_DIR/tmp/$BUILD_ARCH" || exit
+
+  # remove old configs and copy over new
+  rm -rf config auto
+  cp -r "$BASE_DIR"/etc/* .
+  # Make sure conffile specified as arg has correct name
+  cp -f "$BASE_DIR"/"$CONFIG_FILE" terraform.conf
+
+  # copy appcenter list & key
+  if [ "$INCLUDE_APPCENTER" = "yes" ]; then
+    cp "config/appcenter/appcenter.list.binary" "config/archives/appcenter.list.binary"
+    cp "config/appcenter/appcenter.key.binary" "config/archives/appcenter.key.binary"
+  fi
+
+  echo -e "
+#------------------#
+# LIVE-BUILD CLEAN #
+#------------------#
+"
+  lb clean
+
+  echo -e "
+#-------------------#
+# LIVE-BUILD CONFIG #
+#-------------------#
+"
+  lb config
+
+  echo -e "
+#------------------#
+# LIVE-BUILD BUILD #
+#------------------#
+"
+  lb build
+
+  echo -e "
+#---------------------------#
+# MOVE OUTPUT TO BUILDS DIR #
+#---------------------------#
+"
+
+  YYYYMMDD="$(date +%Y%m%d)"
+  OUTPUT_DIR="$BASE_DIR/builds/$BUILD_ARCH"
+  mkdir -p "$OUTPUT_DIR"
+  FNAME="elementaryos-$VERSION-$CHANNEL-$BUILD_ARCH.$YYYYMMDD$OUTPUT_SUFFIX"
+  mv "$BASE_DIR/tmp/$BUILD_ARCH/live-image-$BUILD_ARCH.hybrid.iso" "$OUTPUT_DIR/${FNAME}.iso"
+
+  # cd into output to so {FNAME}.sha256.txt only
+  # includes the filename and not the path to
+  # our file.
+  cd $OUTPUT_DIR
+  md5sum "${FNAME}.iso" | tee "${FNAME}.md5.txt"
+  sha256sum "${FNAME}.iso" | tee "${FNAME}.sha256.txt"
+  cd $BASE_DIR
+}
+
+# remove old builds before creating new ones
+rm -rf "$BASE_DIR"/builds
+
+if [[ "$ARCH" == "all" ]]; then
+    build amd64
+    build i386
+else
+    build "$ARCH"
+fi

--- a/etc/auto/config
+++ b/etc/auto/config
@@ -14,6 +14,17 @@ if [ "$HWE_X11" = "yes" ]; then
     XORG_HWE="xserver-xorg-hwe-${BASEVERSION}"
 fi
 
+case "$ARCH" in
+    amd64|i386)
+        MIRROR_BINARY_URL="http://archive.ubuntu.com/ubuntu/"
+        MIRROR_BINARY_SECURITY_URL="http://security.ubuntu.com/ubuntu/"
+        ;;
+    arm64)
+        MIRROR_BINARY_URL="http://ports.ubuntu.com/ubuntu-ports/"
+        MIRROR_BINARY_SECURITY_URL="http://ports.ubuntu.com/ubuntu-ports/"
+        ;;
+esac
+
 lb config noauto \
     --architectures "$ARCH" \
     --mode debian \
@@ -29,12 +40,12 @@ lb config noauto \
     --checksums md5 \
     --mirror-bootstrap "$MIRROR_URL" \
     --parent-mirror-bootstrap "$MIRROR_URL" \
-    --mirror-chroot-security "http://security.ubuntu.com/ubuntu/" \
-    --parent-mirror-chroot-security "http://security.ubuntu.com/ubuntu/" \
-    --mirror-binary-security "http://security.ubuntu.com/ubuntu/" \
-    --parent-mirror-binary-security "http://security.ubuntu.com/ubuntu/" \
-    --mirror-binary "http://archive.ubuntu.com/ubuntu/" \
-    --parent-mirror-binary "http://archive.ubuntu.com/ubuntu/" \
+    --mirror-chroot-security "$MIRROR_BINARY_SECURITY_URL" \
+    --parent-mirror-chroot-security "$MIRROR_BINARY_SECURITY_URL" \
+    --mirror-binary-security "$MIRROR_BINARY_SECURITY_URL" \
+    --parent-mirror-binary-security "$MIRROR_BINARY_SECURITY_URL" \
+    --mirror-binary "$MIRROR_BINARY_URL" \
+    --parent-mirror-binary "$MIRROR_BINARY_URL" \
     --keyring-packages ubuntu-keyring \
     --apt-options "--yes --option Acquire::Retries=2 --option Acquire::http::Timeout=45" \
     --cache-packages false \

--- a/etc/config/package-lists/pool.list.binary
+++ b/etc/config/package-lists/pool.list.binary
@@ -1,19 +1,26 @@
 b43-fwcutter
-bcmwl-kernel-source
 dkms
-intel-microcode
-iucode-tool
 open-vm-tools-desktop
 setserial
 user-setup
 
 efibootmgr
 secureboot-db
+shim
+shim-signed
 
 #if ARCHITECTURES amd64
+bcmwl-kernel-source
+intel-microcode
+iucode-tool
+
 grub-efi-amd64
 grub-efi-amd64-bin
 grub-efi-amd64-signed
-shim
-shim-signed
+#endif
+
+#if ARCHITECTURES arm64
+grub-efi-arm64
+grub-efi-arm64-bin
+grub-efi-arm64-signed
 #endif

--- a/etc/terraform-arm64.conf
+++ b/etc/terraform-arm64.conf
@@ -1,0 +1,33 @@
+# target architecture - i386, amd64 or all
+ARCH="arm64"
+
+# base codename
+BASECODENAME="noble"
+
+# base version
+BASEVERSION="24.04"
+
+# distribution codename
+CODENAME="circe"
+
+# distribution version
+VERSION="8.0"
+
+# distribution channel
+CHANNEL="stable"
+
+# distribution name
+NAME="elementary OS"
+
+# mirror to fetch packages from
+MIRROR_URL="http://ports.ubuntu.com/ubuntu-ports/"
+
+# use HWE kernel and packages?
+HWE_KERNEL="yes"
+HWE_X11="no"
+
+# use appcenter ppa
+INCLUDE_APPCENTER=""
+
+# suffix for generated .iso files
+OUTPUT_SUFFIX=""

--- a/etc/terraform-daily-8.0-azure-arm64.conf
+++ b/etc/terraform-daily-8.0-azure-arm64.conf
@@ -1,0 +1,33 @@
+# target architecture - i386, amd64 or all
+ARCH="arm64"
+
+# base codename
+BASECODENAME="noble"
+
+# base version
+BASEVERSION="24.04"
+
+# distribution codename
+CODENAME="circe"
+
+# distribution version
+VERSION="8.0"
+
+# distribution channel
+CHANNEL="daily"
+
+# distribution name
+NAME="elementary OS"
+
+# mirror to fetch packages from
+MIRROR_URL="http://azure.ports.ubuntu.com/ubuntu-ports/"
+
+# use HWE kernel and packages?
+HWE_KERNEL="yes"
+HWE_X11="no"
+
+# use appcenter ppa
+INCLUDE_APPCENTER=""
+
+# suffix for generated .iso files
+OUTPUT_SUFFIX=""

--- a/workflows-arm64.sh
+++ b/workflows-arm64.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+CONFIG_FILE="$1"
+KEY="$2"
+SECRET="$3"
+ENDPOINT="$4"
+BUCKET="$5"
+
+./build-arm64.sh "$CONFIG_FILE"
+./upload.sh "$CONFIG_FILE" "$KEY" "$SECRET" "$ENDPOINT" "$BUCKET"


### PR DESCRIPTION
This PR introduces native ARM64 build support. Related to #682.

Thanks to @t3rminus for the initial attempt.

### Current limitations:

1. A newer version of `live-build` is required.
2. ~The `io.elementary.installer` package is currently not included in [metapackages/live-arm64](https://github.com/elementary/metapackages/blob/noble/live-arm64), preventing installation to disk.~

Tested using [UTM](https://github.com/utmapp/UTM) on Apple Silicon Mac.

![Screenshot](https://github.com/user-attachments/assets/12b47ecf-24ba-44e4-8902-3e0c9b5adbf5)