### PR TITLE
Update apparmor-profiles.chroot

### DIFF
--- a/etc/config/hooks/live/apparmor-profiles.chroot
+++ b/etc/config/hooks/live/apparmor-profiles.chroot
@@ -14,6 +14,3 @@ cat << EOF > /usr/lib/systemd/system/apparmor.service.d/99_enable_in_live_mode.c
 [Unit]
 ConditionPathExists=
 EOF
-
-# Enable the experimental bubblewrap profile
-ln -s /usr/share/apparmor/extra-profiles/bwrap-userns-restrict /etc/apparmor.d/


### PR DESCRIPTION
Creating the symlink is now done in default-settings. Should fix this build failure: https://github.com/elementary/os/actions/runs/13847045767/job/38747523616