### PR TITLE
Replace deprecated `apt-key`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,7 @@ apt-get install -y live-build patch gnupg2 binutils zstd
 # anymore, so we add the archive keys manually. This may need to be updated if Ubuntu changes their signing keys
 # To get the current key ID, find `ubuntu-keyring-xxxx-archive.gpg` in /etc/apt/trusted.gpg.d on a running
 # system and run `gpg --keyring /etc/apt/trusted.gpg.d/ubuntu-keyring-xxxx-archive.gpg --list-public-keys `
-apt-key adv --recv-keys --keyserver keyserver.ubuntu.com F6ECB3762474EDA9D21B7022871920D1991BC93C
+gpg --homedir /tmp --no-default-keyring --keyring /etc/apt/trusted.gpg --recv-keys --keyserver keyserver.ubuntu.com F6ECB3762474EDA9D21B7022871920D1991BC93C
 
 # TODO: This patch was submitted upstream at:
 # https://salsa.debian.org/live-team/live-build/-/merge_requests/314


### PR DESCRIPTION
Fixes #723 

`apt-key` will be removed in the upcoming Debian Trixie release. This PR ensures compatibility with newer build environments, which is useful for https://github.com/elementary/os/pull/754.