### PR TITLE
daily-8.0: Enable HWE Kernel

### DIFF
--- a/etc/terraform-daily-8.0-azure.conf
+++ b/etc/terraform-daily-8.0-azure.conf
@@ -23,7 +23,7 @@ NAME="elementary OS"
 MIRROR_URL="http://azure.archive.ubuntu.com/ubuntu/"
 
 # use HWE kernel and packages?
-HWE_KERNEL="no"
+HWE_KERNEL="yes"
 HWE_X11="no"
 
 # use appcenter ppa


### PR DESCRIPTION
From https://github.com/elementary/os/pull/754#discussion_r2173755383:

> This looks like because the daily conf was originally built on Mantic, which was not a LTS: #690. After that the daily conf was rebased on Noble but we seemed to forget updating this parameter.

Haven't been built and tested on my local yet though.
