### PR TITLE
Preserve our /etc/os-release

### DIFF
--- a/etc/config/hooks/live/revert-os-release-divert.chroot
+++ b/etc/config/hooks/live/revert-os-release-divert.chroot
@@ -10,5 +10,5 @@ OS_RELEASE_DIVERTED="${OS_RELEASE}.debootstrap"
 dpkg-divert --list "$OS_RELEASE" | grep -q "$OS_RELEASE"
 if [ $? -eq 0 ]; then
     mv "$OS_RELEASE_DIVERTED" "$OS_RELEASE"
-    dpkg-divert --local --remove --no-rename --divert "$OS_RELEASE_DIVERTED" "$OS_RELEASE"
+    dpkg-divert --quiet --local --remove --no-rename --divert "$OS_RELEASE_DIVERTED" "$OS_RELEASE"
 fi


### PR DESCRIPTION
Fixes #770

Tested by building an Daily arm64 image.

On live boot:

<img width="1392" height="907" alt="スクリーンショット 2025-08-13 23 17 35" src="https://github.com/user-attachments/assets/ee445fb4-7986-4803-8903-93e0397112f5" />

While installation:

<img width="1392" height="907" alt="スクリーンショット 2025-08-13 23 18 48" src="https://github.com/user-attachments/assets/5e59b048-b6d7-4d10-ba5e-1aeda5b5a6e1" />

After installation:

<img width="1392" height="907" alt="スクリーンショット 2025-08-13 23 23 26" src="https://github.com/user-attachments/assets/10b45ed6-43e6-40a5-a1c1-df3109b939b9" />
