### PR TITLE
build: Update debootstrap symlink to resolute

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,8 +32,8 @@ apt-get install -y live-build patch gnupg2 binutils zstd
 # system and run `gpg --keyring /etc/apt/trusted.gpg.d/ubuntu-keyring-xxxx-archive.gpg --list-public-keys `
 gpg --homedir /tmp --no-default-keyring --keyring /etc/apt/trusted.gpg --recv-keys --keyserver keyserver.ubuntu.com F6ECB3762474EDA9D21B7022871920D1991BC93C
 
-# TODO: Remove this once debootstrap can natively build noble images:
-ln -sfn /usr/share/debootstrap/scripts/gutsy /usr/share/debootstrap/scripts/noble
+# TODO: Remove this once debootstrap can natively build resolute images:
+ln -sfn /usr/share/debootstrap/scripts/gutsy /usr/share/debootstrap/scripts/resolute
 
 build () {
   BUILD_ARCH="$1"


### PR DESCRIPTION
debootstrap available in debian:latest Docker image (trixie) now already has symlink from gasty to noble by default.

```
root@1ea7726eeaa1:/# ls -ld /usr/share/debootstrap/scripts/noble
lrwxrwxrwx. 1 root root 5 Apr 24  2025 /usr/share/debootstrap/scripts/noble -> gutsy
root@1ea7726eeaa1:/# ls -ld /usr/share/debootstrap/scripts/resolute
ls: cannot access '/usr/share/debootstrap/scripts/resolute': No such file or directory
root@1ea7726eeaa1:/#
```

<details>

<summary>Full stdout of the above output (install debootstrap on the debian:latest Docker image)</summary>

```
ryo@fedora-host:~/work/elementary/os (main *=)$ docker run -it debian:latest bash
WARNING: IPv4 forwarding is disabled. Networking will not work.
root@1ea7726eeaa1:/# apt update
Get:1 http://deb.debian.org/debian trixie InRelease [140 kB]
Get:2 http://deb.debian.org/debian trixie-updates InRelease [47.3 kB]
Get:3 http://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
Get:4 http://deb.debian.org/debian trixie/main amd64 Packages [9671 kB]
Get:5 http://deb.debian.org/debian trixie-updates/main amd64 Packages [5412 B]
Get:6 http://deb.debian.org/debian-security trixie-security/main amd64 Packages [171 kB]
Fetched 10.1 MB in 2s (4103 kB/s)
All packages are up to date.
root@1ea7726eeaa1:/# apt install debootstrap
Installing:
  debootstrap

Installing dependencies:
  arch-test        distro-info       libffi8         libidn2-0    libpsl5t64  libunistring5  publicsuffix
  ca-certificates  distro-info-data  libgnutls30t64  libp11-kit0  libtasn1-6  openssl        wget

Suggested packages:
  squid-deb-proxy-client  ubuntu-archive-keyring  binutils  xz-utils  zstd  shunit2  gnutls-bin

Summary:
  Upgrading: 0, Installing: 15, Removing: 0, Not Upgrading: 0
  Download size: 5645 kB
  Space needed: 16.5 MB / 147 GB available

Continue? [Y/n] y
Get:1 http://deb.debian.org/debian trixie/main amd64 openssl amd64 3.5.6-1~deb13u1 [1503 kB]
Get:2 http://deb.debian.org/debian trixie/main amd64 ca-certificates all 20250419 [162 kB]
Get:3 http://deb.debian.org/debian trixie/main amd64 libunistring5 amd64 1.3-2 [477 kB]
Get:4 http://deb.debian.org/debian trixie/main amd64 libidn2-0 amd64 2.3.8-2 [109 kB]
Get:5 http://deb.debian.org/debian trixie/main amd64 libffi8 amd64 3.4.8-2 [24.1 kB]
Get:6 http://deb.debian.org/debian trixie/main amd64 libp11-kit0 amd64 0.25.5-3 [425 kB]
Get:7 http://deb.debian.org/debian trixie/main amd64 libtasn1-6 amd64 4.20.0-2 [49.9 kB]
Get:8 http://deb.debian.org/debian-security trixie-security/main amd64 libgnutls30t64 amd64 3.8.9-3+deb13u4 [1469 kB]
Get:9 http://deb.debian.org/debian trixie/main amd64 libpsl5t64 amd64 0.21.2-1.1+b1 [57.2 kB]
Get:10 http://deb.debian.org/debian trixie/main amd64 wget amd64 1.25.0-2 [984 kB]
Get:11 http://deb.debian.org/debian trixie/main amd64 arch-test all 0.22-1 [12.9 kB]
Get:12 http://deb.debian.org/debian trixie/main amd64 distro-info-data all 0.66+deb13u2 [6792 B]
Get:13 http://deb.debian.org/debian trixie/main amd64 distro-info amd64 1.13 [18.9 kB]
Get:14 http://deb.debian.org/debian trixie/main amd64 debootstrap all 1.0.141 [50.1 kB]
Get:15 http://deb.debian.org/debian trixie/main amd64 publicsuffix all 20250328.1952-0.1 [296 kB]
Fetched 5645 kB in 1s (8241 kB/s)
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 79, <STDIN> line 15.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.40.1 /usr/local/share/perl/5.40.1 /usr/lib/x86_64-linux-gnu/perl5/5.40 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.40 /usr/share/perl/5.40 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 8, <STDIN> line 15.)
debconf: falling back to frontend: Teletype
Preconfiguring packages ...
Selecting previously unselected package openssl.
(Reading database ... 4936 files and directories currently installed.)
Preparing to unpack .../00-openssl_3.5.6-1~deb13u1_amd64.deb ...
Unpacking openssl (3.5.6-1~deb13u1) ...
Selecting previously unselected package ca-certificates.
Preparing to unpack .../01-ca-certificates_20250419_all.deb ...
Unpacking ca-certificates (20250419) ...
Selecting previously unselected package libunistring5:amd64.
Preparing to unpack .../02-libunistring5_1.3-2_amd64.deb ...
Unpacking libunistring5:amd64 (1.3-2) ...
Selecting previously unselected package libidn2-0:amd64.
Preparing to unpack .../03-libidn2-0_2.3.8-2_amd64.deb ...
Unpacking libidn2-0:amd64 (2.3.8-2) ...
Selecting previously unselected package libffi8:amd64.
Preparing to unpack .../04-libffi8_3.4.8-2_amd64.deb ...
Unpacking libffi8:amd64 (3.4.8-2) ...
Selecting previously unselected package libp11-kit0:amd64.
Preparing to unpack .../05-libp11-kit0_0.25.5-3_amd64.deb ...
Unpacking libp11-kit0:amd64 (0.25.5-3) ...
Selecting previously unselected package libtasn1-6:amd64.
Preparing to unpack .../06-libtasn1-6_4.20.0-2_amd64.deb ...
Unpacking libtasn1-6:amd64 (4.20.0-2) ...
Selecting previously unselected package libgnutls30t64:amd64.
Preparing to unpack .../07-libgnutls30t64_3.8.9-3+deb13u4_amd64.deb ...
Unpacking libgnutls30t64:amd64 (3.8.9-3+deb13u4) ...
Selecting previously unselected package libpsl5t64:amd64.
Preparing to unpack .../08-libpsl5t64_0.21.2-1.1+b1_amd64.deb ...
Unpacking libpsl5t64:amd64 (0.21.2-1.1+b1) ...
Selecting previously unselected package wget.
Preparing to unpack .../09-wget_1.25.0-2_amd64.deb ...
Unpacking wget (1.25.0-2) ...
Selecting previously unselected package arch-test.
Preparing to unpack .../10-arch-test_0.22-1_all.deb ...
Unpacking arch-test (0.22-1) ...
Selecting previously unselected package distro-info-data.
Preparing to unpack .../11-distro-info-data_0.66+deb13u2_all.deb ...
Unpacking distro-info-data (0.66+deb13u2) ...
Selecting previously unselected package distro-info.
Preparing to unpack .../12-distro-info_1.13_amd64.deb ...
Unpacking distro-info (1.13) ...
Selecting previously unselected package debootstrap.
Preparing to unpack .../13-debootstrap_1.0.141_all.deb ...
Unpacking debootstrap (1.0.141) ...
Selecting previously unselected package publicsuffix.
Preparing to unpack .../14-publicsuffix_20250328.1952-0.1_all.deb ...
Unpacking publicsuffix (20250328.1952-0.1) ...
Setting up distro-info-data (0.66+deb13u2) ...
Setting up libunistring5:amd64 (1.3-2) ...
Setting up libffi8:amd64 (3.4.8-2) ...
Setting up libtasn1-6:amd64 (4.20.0-2) ...
Setting up arch-test (0.22-1) ...
Setting up openssl (3.5.6-1~deb13u1) ...
Setting up publicsuffix (20250328.1952-0.1) ...
Setting up distro-info (1.13) ...
Setting up libidn2-0:amd64 (2.3.8-2) ...
Setting up ca-certificates (20250419) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 79.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.40.1 /usr/local/share/perl/5.40.1 /usr/lib/x86_64-linux-gnu/perl5/5.40 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.40 /usr/share/perl/5.40 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 8.)
debconf: falling back to frontend: Teletype
Updating certificates in /etc/ssl/certs...
150 added, 0 removed; done.
Setting up libp11-kit0:amd64 (0.25.5-3) ...
Setting up libgnutls30t64:amd64 (3.8.9-3+deb13u4) ...
Setting up libpsl5t64:amd64 (0.21.2-1.1+b1) ...
Setting up wget (1.25.0-2) ...
Setting up debootstrap (1.0.141) ...
Processing triggers for libc-bin (2.41-12+deb13u3) ...
Processing triggers for ca-certificates (20250419) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
root@1ea7726eeaa1:/# ls -ld /usr/share/debootstrap/scripts/noble
lrwxrwxrwx. 1 root root 5 Apr 24  2025 /usr/share/debootstrap/scripts/noble -> gutsy
root@1ea7726eeaa1:/# ls -ld /usr/share/debootstrap/scripts/resolute
ls: cannot access '/usr/share/debootstrap/scripts/resolute': No such file or directory
root@1ea7726eeaa1:/#
```

</details>
