### PR TITLE
package-lists: Update package name of Broadcom STA Wireless driver

### DIFF
--- a/etc/config/package-lists/pool.list.binary
+++ b/etc/config/package-lists/pool.list.binary
@@ -10,7 +10,7 @@ shim
 shim-signed
 
 #if ARCHITECTURES amd64
-bcmwl-kernel-source
+broadcom-sta-dkms
 intel-microcode
 iucode-tool
 


### PR DESCRIPTION
Fixes #805

### Checklist
- [x] Check if the build error no longer occurs
