### PR TITLE
POC: use bootc for isos and image-based updates

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,38 @@
+FROM ghcr.io/jmarrero/ubuntu-bootc:latest
+
+ARG CHANNEL=daily
+ARG BASECODENAME=resolute
+ARG VERSION=9.0
+ARG CODENAME=tanit
+ARG NAME="elementary OS"
+ARG ARCH=amd64
+
+LABEL org.opencontainers.image.title="${NAME}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.description="elementary OS bootc image" \
+      org.opencontainers.image.base.name="ghcr.io/jmarrero/ubuntu-bootc:latest" \
+      os.channel="${CHANNEL}" \
+      os.codename="${CODENAME}"
+
+COPY etc/config/archives/elementary.key /etc/apt/trusted.gpg.d/elementary.gpg
+COPY etc/config/archives/patches.key /etc/apt/trusted.gpg.d/patches.gpg
+COPY etc/config/archives/patches.pref /etc/apt/preferences.d/os-patches.pref
+
+RUN echo "Types: deb" > /etc/apt/sources.list.d/elementary.sources \
+    && echo "URIs: https://ppa.launchpadcontent.net/elementary-os/${CHANNEL}/ubuntu" >> /etc/apt/sources.list.d/elementary.sources \
+    && echo "Suites: ${BASECODENAME}" >> /etc/apt/sources.list.d/elementary.sources \
+    && echo "Components: main" >> /etc/apt/sources.list.d/elementary.sources \
+    && echo "Signed-By: /etc/apt/trusted.gpg.d/elementary.gpg" >> /etc/apt/sources.list.d/elementary.sources \
+    && echo "Types: deb" > /etc/apt/sources.list.d/os-patches.sources \
+    && echo "URIs: https://ppa.launchpadcontent.net/elementary-os/os-patches/ubuntu" >> /etc/apt/sources.list.d/os-patches.sources \
+    && echo "Suites: ${BASECODENAME}" >> /etc/apt/sources.list.d/os-patches.sources \
+    && echo "Components: main" >> /etc/apt/sources.list.d/os-patches.sources \
+    && echo "Signed-By: /etc/apt/trusted.gpg.d/patches.gpg" >> /etc/apt/sources.list.d/os-patches.sources
+
+RUN apt-get update \
+    && apt-get install -y elementary-desktop elementary-minimal elementary-standard \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/lib/systemd/system/apparmor.service.d \
+    && printf '[Unit]\nConditionPathExists=\n' > /usr/lib/systemd/system/apparmor.service.d/99_enable_in_live_mode.conf

--- a/Containerfile
+++ b/Containerfile
@@ -36,3 +36,5 @@ RUN apt-get update \
 
 RUN mkdir -p /usr/lib/systemd/system/apparmor.service.d \
     && printf '[Unit]\nConditionPathExists=\n' > /usr/lib/systemd/system/apparmor.service.d/99_enable_in_live_mode.conf
+
+RUN bootc container lint

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ echo -e "
 
 
 #--------------------------------#
-# BUILD & LINT CONTAINER IMAGE    #
+# BUILD CONTAINER IMAGE    #
 #--------------------------------#
 "
 
@@ -40,8 +40,6 @@ podman build \
   -t "$IMAGE_TAG" \
   -f Containerfile \
   "$BASE_DIR"
-
-bootc container lint "$IMAGE_TAG"
 
 if [ -n "$REGISTRY" ] && [ -n "$IMAGE_NAME" ]; then
   REMOTE_TAG="${VERSION}-${CHANNEL}-${ARCH}.${YYYYMMDD}${OUTPUT_SUFFIX}"

--- a/build.sh
+++ b/build.sh
@@ -18,78 +18,81 @@ BASE_DIR="$PWD"
 source "$BASE_DIR"/"$CONFIG_FILE"
 
 echo -e "
-#----------------------#
-# INSTALL DEPENDENCIES #
-#----------------------#
+
+
+#--------------------------------#
+# BUILD & LINT CONTAINER IMAGE    #
+#--------------------------------#
 "
 
-apt-get update
-apt-get install -y live-build patch gnupg2 binutils zstd
+YYYYMMDD="$(date +%Y%m%d)"
+IMAGE_TAG="elementaryos-$VERSION-$CHANNEL-$ARCH.$YYYYMMDD$OUTPUT_SUFFIX"
+OUTPUT_DIR="$BASE_DIR/builds/$ARCH"
+mkdir -p "$OUTPUT_DIR"
 
-# The Debian repositories don't seem to have the `ubuntu-keyring` or `ubuntu-archive-keyring` packages
-# anymore, so we add the archive keys manually. This may need to be updated if Ubuntu changes their signing keys
-# To get the current key ID, find `ubuntu-keyring-xxxx-archive.gpg` in /etc/apt/trusted.gpg.d on a running
-# system and run `gpg --keyring /etc/apt/trusted.gpg.d/ubuntu-keyring-xxxx-archive.gpg --list-public-keys `
-gpg --homedir /tmp --no-default-keyring --keyring /etc/apt/trusted.gpg --recv-keys --keyserver keyserver.ubuntu.com F6ECB3762474EDA9D21B7022871920D1991BC93C
+podman build \
+  --build-arg CHANNEL="$CHANNEL" \
+  --build-arg BASECODENAME="$BASECODENAME" \
+  --build-arg VERSION="$VERSION" \
+  --build-arg CODENAME="$CODENAME" \
+  --build-arg NAME="$NAME" \
+  --build-arg ARCH="$ARCH" \
+  -t "$IMAGE_TAG" \
+  -f Containerfile \
+  "$BASE_DIR"
 
-# TODO: Remove this once debootstrap can natively build resolute images:
-ln -sfn /usr/share/debootstrap/scripts/gutsy /usr/share/debootstrap/scripts/resolute
+bootc container lint "$IMAGE_TAG"
 
-build () {
-  BUILD_ARCH="$1"
-
-  mkdir -p "$BASE_DIR/tmp/$BUILD_ARCH"
-  cd "$BASE_DIR/tmp/$BUILD_ARCH" || exit
-
-  # remove old configs and copy over new
-  rm -rf config auto
-  cp -r "$BASE_DIR"/etc/* .
-  # Make sure conffile specified as arg has correct name
-  cp -f "$BASE_DIR"/"$CONFIG_FILE" terraform.conf
+if [ -n "$REGISTRY" ] && [ -n "$IMAGE_NAME" ]; then
+  REMOTE_TAG="${VERSION}-${CHANNEL}-${ARCH}.${YYYYMMDD}${OUTPUT_SUFFIX}"
+  REMOTE_IMAGE="${REGISTRY}/${IMAGE_NAME}:${REMOTE_TAG}"
 
   echo -e "
-#------------------#
-# LIVE-BUILD CLEAN #
-#------------------#
-"
-  lb clean
-
-  echo -e "
-#-------------------#
-# LIVE-BUILD CONFIG #
-#-------------------#
-"
-  lb config
-
-  echo -e "
-#------------------#
-# LIVE-BUILD BUILD #
-#------------------#
-"
-  lb build
-
-  echo -e "
-#---------------------------#
-# MOVE OUTPUT TO BUILDS DIR #
-#---------------------------#
+#--------------------------------------------------------#
+# PUSH TO REGISTRY SO EXISTING INSTALLS CAN BOOTC UPDATE #
+#--------------------------------------------------------#
 "
 
-  YYYYMMDD="$(date +%Y%m%d)"
-  OUTPUT_DIR="$BASE_DIR/builds/$BUILD_ARCH"
-  mkdir -p "$OUTPUT_DIR"
-  FNAME="elementaryos-$VERSION-$CHANNEL-$BUILD_ARCH.$YYYYMMDD$OUTPUT_SUFFIX"
-  mv "$BASE_DIR/tmp/$BUILD_ARCH/live-image-$BUILD_ARCH.hybrid.iso" "$OUTPUT_DIR/${FNAME}.iso"
+  podman tag "$IMAGE_TAG" "$REMOTE_IMAGE"
+  podman push "$REMOTE_IMAGE"
 
-  # cd into output to so {FNAME}.sha256.txt only
-  # includes the filename and not the path to
-  # our file.
-  cd $OUTPUT_DIR
-  md5sum "${FNAME}.iso" | tee "${FNAME}.md5.txt"
-  sha256sum "${FNAME}.iso" | tee "${FNAME}.sha256.txt"
-  cd $BASE_DIR
-}
+  if [ "$CHANNEL" = "stable" ]; then
+    LATEST_IMAGE="${REGISTRY}/${IMAGE_NAME}:latest"
+    podman tag "$IMAGE_TAG" "$LATEST_IMAGE"
+    podman push "$LATEST_IMAGE"
+  fi
 
-# remove old builds before creating new ones
-rm -rf "$BASE_DIR"/builds
+  echo "Pushed: $REMOTE_IMAGE"
+fi
 
-build "$ARCH"
+echo -e "
+#---------------------------------------------#
+# GENERATE ISO FROM IMAGE FOR NEW INSTALLS    #
+#---------------------------------------------#
+"
+
+if [ "$BUILD_ISO" = "true" ]; then
+  podman run --rm --privileged \
+    -v /var/lib/containers/storage:/var/lib/containers/storage \
+    -v "$OUTPUT_DIR:/output" \
+    ghcr.io/osbuild/image-builder-cli:latest \
+    --type "bootc-generic-iso" \
+    "$IMAGE_TAG"
+
+  ISO_FILE=$(find "$OUTPUT_DIR" -maxdepth 1 -name "*.iso" -type f | head -1)
+  if [ -n "$ISO_FILE" ]; then
+    FNAME="elementaryos-$VERSION-$CHANNEL-$ARCH.$YYYYMMDD$OUTPUT_SUFFIX"
+    mv "$ISO_FILE" "$OUTPUT_DIR/${FNAME}.iso"
+    cd "$OUTPUT_DIR"
+    md5sum "${FNAME}.iso" | tee "${FNAME}.md5.txt"
+    sha256sum "${FNAME}.iso" | tee "${FNAME}.sha256.txt"
+    cd "$BASE_DIR"
+  fi
+fi
+
+echo -e "
+#------------------------#
+# IMAGE BUILT SUCCESSFULLY
+#------------------------#
+"
+echo "Image: $IMAGE_TAG"

--- a/etc/terraform-daily-9.0-azure-amd64.conf
+++ b/etc/terraform-daily-9.0-azure-amd64.conf
@@ -28,3 +28,10 @@ HWE_X11="no"
 
 # suffix for generated .iso files
 OUTPUT_SUFFIX=""
+
+# generate installer ISO from bootc image via bootc-image-builder
+BUILD_ISO="true"
+
+# container registry and image name (for bootc image push)
+REGISTRY="ghcr.io"
+IMAGE_NAME="elementary/os"

--- a/etc/terraform-daily-9.0-azure-arm64.conf
+++ b/etc/terraform-daily-9.0-azure-arm64.conf
@@ -28,3 +28,10 @@ HWE_X11="no"
 
 # suffix for generated .iso files
 OUTPUT_SUFFIX=""
+
+# generate installer ISO from bootc image via bootc-image-builder
+BUILD_ISO="true"
+
+# container registry and image name (for bootc image push)
+REGISTRY="ghcr.io"
+IMAGE_NAME="elementary/os"


### PR DESCRIPTION
Upside is more of the work gets moved onto podman and image-builder. Downside is it's not 100% ubuntu/debian ready yet IMO.

The flow becomes in pseudocode:

- Build: `podman build Containerfile` Create image. Build shenanigans are moved to Containerfile
- Install: `podman run ghcr.io/osbuild/image-builder-cli:latest --type bootc-generic-iso` to build ISO from image. OR keep existing live-build. Either way, installer would need to run `bootc install to-disk` instead of `debootstrap` - big change I know.
- Update: `podman push ghcr.io/elementary/os:latest` Push image to registry so all existing ElementaryOS installs can `sudo bootc update` (settings app would need to be adapted), even over versions 8=>9=>10 just like Bazzite upgrades between Fedora major versions

Downsides are:
- We're relying on a not-yet stable source for our ubuntu-bootc images https://github.com/jmarrero/ubuntu-bootc. Maybe [bootcrew](https://github.com/bootcrew/mono) will maintain these mid-term - tbd.
- We're relying on still-implemented composefs backend.
- Installer would need to be rewritten/wired around deploying an image with bootc install to-disk
- no sudo apt install outside of distrobox or homebrew. system becomes macos style. 


Upsides:
- no hard-to-debug breakage through sudo apt install and ppa package drift
- upgrades between major elementary os releases, :latest - forever



References:
- https://github.com/jmarrero/ubuntu-bootc/
- https://github.com/bootcrew/mono
- https://github.com/ublue-os/bazzite
- https://github.com/tulilirockz/zirconium (uses mkosi/sysupdate)
- https://github.com/atomic-shindig/ubuntu-atomic-remix (uses mkosi/sysupdate)

Builds image-mode elementary OS for image-based updates and isos with CNCF bootc technology. Addresses https://github.com/elementary/os/issues/724 et al